### PR TITLE
fix(cli): harden CI non-interactive behavior and exit-code docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,16 @@ npx librainian status --json --ci --quiet
 npx librainian bootstrap --mode fast --yes --no-progress --no-color
 ```
 
+GitHub Actions example:
+
+```yaml
+- name: Check index freshness (machine-readable)
+  run: npx librainian status --json --quiet | jq -e '.freshness.staleFiles == 0 and .freshness.missingFiles == 0'
+
+- name: Refresh index non-interactively
+  run: npx librainian index --force --incremental --yes --quiet
+```
+
 ## Pre-Commit Hook Integration
 
 LiBrainian supports staged-file incremental indexing for commit-time freshness:

--- a/src/cli/__tests__/help_exit_codes.test.ts
+++ b/src/cli/__tests__/help_exit_codes.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { getCommandHelp } from '../help.js';
+
+describe('help exit code documentation', () => {
+  it('documents status-specific and default exit codes', () => {
+    const help = getCommandHelp('status');
+    expect(help).toContain('STATUS EXIT CODES:');
+    expect(help).toContain('EXIT CODES (DEFAULT):');
+    expect(help).toContain('10-13  Storage/index failures');
+  });
+
+  it('documents default exit codes for regular commands', () => {
+    const help = getCommandHelp('query');
+    expect(help).toContain('EXIT CODES (DEFAULT):');
+  });
+
+  it('does not duplicate command-defined exit code sections', () => {
+    const help = getCommandHelp('doctor');
+    const matches = help.match(/exit codes:/gi) ?? [];
+    expect(matches.length).toBe(1);
+  });
+});

--- a/src/cli/__tests__/runtime_mode.test.ts
+++ b/src/cli/__tests__/runtime_mode.test.ts
@@ -17,6 +17,20 @@ describe('cli runtime mode', () => {
     expect(mode.assumeYes).toBe(true);
   });
 
+  it('detects CI mode from GITHUB_ACTIONS environment', () => {
+    const mode = deriveCliRuntimeMode({
+      args: [],
+      jsonMode: false,
+      env: { GITHUB_ACTIONS: 'true' },
+      stdoutIsTTY: true,
+      stderrIsTTY: true,
+    });
+
+    expect(mode.ci).toBe(true);
+    expect(mode.nonInteractive).toBe(true);
+    expect(mode.assumeYes).toBe(true);
+  });
+
   it('detects non-interactive mode when stdout/stderr are not TTY', () => {
     const mode = deriveCliRuntimeMode({
       args: [],
@@ -42,6 +56,18 @@ describe('cli runtime mode', () => {
     expect(mode.assumeYes).toBe(true);
     expect(mode.quiet).toBe(true);
     expect(mode.noProgress).toBe(true);
+    expect(mode.noColor).toBe(true);
+  });
+
+  it('respects NO_COLOR environment variable', () => {
+    const mode = deriveCliRuntimeMode({
+      args: [],
+      jsonMode: false,
+      env: { NO_COLOR: '1' },
+      stdoutIsTTY: true,
+      stderrIsTTY: true,
+    });
+
     expect(mode.noColor).toBe(true);
   });
 

--- a/src/cli/commands/__tests__/index.test.ts
+++ b/src/cli/commands/__tests__/index.test.ts
@@ -212,7 +212,7 @@ describe('indexCommand', () => {
       ]);
     });
 
-    it('fails when selector resolves no candidate files', async () => {
+    it('treats empty selector result as no-op success', async () => {
       vi.mocked(getGitStatusChanges).mockResolvedValue(null);
       const options: IndexCommandOptions = {
         workspace: mockWorkspace,
@@ -221,8 +221,8 @@ describe('indexCommand', () => {
         incremental: true,
       };
 
-      await expect(indexCommand(options)).rejects.toThrow(CliError);
-      await expect(indexCommand(options)).rejects.toThrow('No modified files found to index');
+      await expect(indexCommand(options)).resolves.toBeUndefined();
+      expect(mockLibrarian.reindexFiles).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- make `librarian index`/`librarian update` selector modes CI-safe by treating empty git selections as a no-op success
- document command help exit codes consistently (default mapping + status-specific exit codes)
- add runtime-mode coverage for `GITHUB_ACTIONS=true` and `NO_COLOR`
- add README CI snippet for `status --json --quiet` and non-interactive incremental indexing

## Why
Issue #230 targets CI/non-interactive ergonomics. The highest-impact pain point was selector-based indexing failing in clean CI runs with no changed files.

## Validation
- `npm test -- --run src/cli/commands/__tests__/index.test.ts src/cli/__tests__/help_exit_codes.test.ts src/cli/__tests__/runtime_mode.test.ts`
- `npm test -- --run src/cli/commands/__tests__/status.test.ts src/cli/__tests__/help_update_alias.test.ts src/cli/__tests__/uninstall_help.test.ts`
- `npm test -- --run src/mcp/__tests__/schema.test.ts src/mcp/__tests__/query_and_bundle_pagination.test.ts src/mcp/__tests__/request_human_review.test.ts`
- `npm run typecheck`
- `npm test -- --run`

Closes #230
