### PR TITLE
fix(security): implement secrets scan CLI and redaction hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ GitHub Actions example:
 
 - name: Refresh index non-interactively
   run: npx librainian index --force --incremental --yes --quiet
+
+- name: Audit redaction totals
+  run: npx librainian scan --secrets --json | jq '.redactions'
 ```
 
 ## Pre-Commit Hook Integration

--- a/src/__tests__/librarian.test.ts
+++ b/src/__tests__/librarian.test.ts
@@ -266,11 +266,13 @@ it('redacts secrets and minimizes snippets', () => {
   const privateKeyFooter = ['-----END', 'PRIVATE', 'KEY-----'].join(' ');
   const apiKey = ['1234567890', '1234567890'].join('');
   const token = ['ABCD', '1234', 'EFGH', '5678', 'IJKL'].join('');
+  const githubToken = ['ghp_', '1234567890', 'abcdefghij', 'KLMNOPQRST'].join('');
   const awsKey = ['AKIA', '1234567890ABCDEF'].join('');
   const input = [
     `api_key: '${apiKey}'`,
     'password = "hunter2"',
     `token: '${token}'`,
+    githubToken,
     awsKey,
     privateKeyHeader,
     'abc',
@@ -278,9 +280,16 @@ it('redacts secrets and minimizes snippets', () => {
   ].join('\n');
 
   const result = redactText(input);
-  for (const type of ['api_key', 'password', 'token', 'aws_key', 'private_key'] as const) {
+  const expectedCounts = {
+    api_key: 1,
+    password: 1,
+    token: 2,
+    aws_key: 1,
+    private_key: 1,
+  } as const;
+  for (const type of Object.keys(expectedCounts) as Array<keyof typeof expectedCounts>) {
     expect(result.text).toContain(`[REDACTED:${type}]`);
-    expect(result.counts.by_type[type]).toBe(1);
+    expect(result.counts.by_type[type]).toBe(expectedCounts[type]);
   }
 
   const minimized = minimizeSnippet(

--- a/src/api/redaction.ts
+++ b/src/api/redaction.ts
@@ -7,7 +7,7 @@ export interface RedactionResult { text: string; counts: RedactionCounts; }
 export interface SnippetMinimizationConfig { maxChars?: number; contextLines?: number; }
 export interface SnippetMinimizationResult { text: string; truncated: boolean; originalLength: number; }
 export interface RedactionAuditReportV1 { kind: 'RedactionAuditReport.v1'; schema_version: 1; created_at: string; canon: Awaited<ReturnType<typeof computeCanonRef>>; environment: ReturnType<typeof computeEnvironmentRef>; workspace: string; redactions: RedactionCounts; }
-const REDACTION_PATTERNS: Array<{ type: RedactionType; regex: RegExp }> = [{ type: 'api_key', regex: /api[_-]?key\s*[:=]\s*['"][^'"]{20,}['"]/gi }, { type: 'password', regex: /password\s*[:=]\s*['"][^'"]+['"]/gi }, { type: 'token', regex: /token\s*[:=]\s*['"][A-Za-z0-9+/=]{20,}['"]/gi }, { type: 'aws_key', regex: /AKIA[0-9A-Z]{16}/g }, { type: 'private_key', regex: /-----BEGIN (?:RSA |EC )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC )?PRIVATE KEY-----/g }];
+const REDACTION_PATTERNS: Array<{ type: RedactionType; regex: RegExp }> = [{ type: 'api_key', regex: /api[_-]?key\s*[:=]\s*['"][^'"]{20,}['"]/gi }, { type: 'password', regex: /password\s*[:=]\s*['"][^'"]+['"]/gi }, { type: 'token', regex: /token\s*[:=]\s*['"][A-Za-z0-9+/=]{20,}['"]|gh[pousr]_[A-Za-z0-9]{20,}/gi }, { type: 'aws_key', regex: /AKIA[0-9A-Z]{16}/g }, { type: 'private_key', regex: /-----BEGIN (?:RSA |EC )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC )?PRIVATE KEY-----/g }];
 export const DEFAULT_SNIPPET_LIMITS = { maxChars: 2000, contextLines: 5 };
 const SNIPPET_GAP_MARKER = '... [snip] ...';
 const resolveAuditDir = (workspaceRoot: string): string => path.join(workspaceRoot, 'state', 'audits', 'librarian', 'redaction');

--- a/src/cli/commands/__tests__/scan.test.ts
+++ b/src/cli/commands/__tests__/scan.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { scanCommand } from '../scan.js';
+
+describe('scanCommand', () => {
+  let workspace: string;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'librarian-scan-'));
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    await fs.rm(workspace, { recursive: true, force: true });
+  });
+
+  it('emits JSON summary for latest redaction audit report', async () => {
+    const reportDir = path.join(
+      workspace,
+      'state',
+      'audits',
+      'librarian',
+      'redaction',
+      '2026-02-20T12-00-00-000Z'
+    );
+    await fs.mkdir(reportDir, { recursive: true });
+    await fs.writeFile(
+      path.join(reportDir, 'RedactionAuditReport.v1.json'),
+      JSON.stringify({
+        kind: 'RedactionAuditReport.v1',
+        schema_version: 1,
+        created_at: '2026-02-20T12:00:00.000Z',
+        workspace,
+        redactions: {
+          total: 4,
+          by_type: {
+            api_key: 0,
+            password: 1,
+            token: 2,
+            aws_key: 0,
+            private_key: 1,
+          },
+        },
+      }),
+      'utf8'
+    );
+
+    await scanCommand({
+      workspace,
+      args: ['--secrets'],
+      rawArgs: ['scan', '--secrets', '--json'],
+    });
+
+    const payload = consoleLogSpy.mock.calls
+      .map((call) => call[0])
+      .find((value) => typeof value === 'string' && value.includes('"kind"')) as string | undefined;
+    expect(payload).toBeTruthy();
+
+    const parsed = JSON.parse(payload ?? '{}') as {
+      reportFound?: boolean;
+      redactions?: { total?: number; by_type?: { token?: number; private_key?: number } };
+    };
+    expect(parsed.reportFound).toBe(true);
+    expect(parsed.redactions?.total).toBe(4);
+    expect(parsed.redactions?.by_type?.token).toBe(2);
+    expect(parsed.redactions?.by_type?.private_key).toBe(1);
+  });
+
+  it('emits zero redaction summary when no report exists', async () => {
+    await scanCommand({
+      workspace,
+      args: ['--secrets'],
+      rawArgs: ['scan', '--secrets', '--json'],
+    });
+
+    const payload = consoleLogSpy.mock.calls
+      .map((call) => call[0])
+      .find((value) => typeof value === 'string' && value.includes('"kind"')) as string | undefined;
+    expect(payload).toBeTruthy();
+
+    const parsed = JSON.parse(payload ?? '{}') as {
+      reportFound?: boolean;
+      redactions?: { total?: number };
+    };
+    expect(parsed.reportFound).toBe(false);
+    expect(parsed.redactions?.total).toBe(0);
+  });
+
+  it('fails closed when scan mode is missing', async () => {
+    await expect(
+      scanCommand({
+        workspace,
+        args: [],
+        rawArgs: ['scan'],
+      })
+    ).rejects.toThrow('Use --secrets');
+  });
+});

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -1,0 +1,127 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { parseArgs } from 'node:util';
+import { createEmptyRedactionCounts, type RedactionAuditReportV1 } from '../../api/redaction.js';
+import { CliError } from '../errors.js';
+
+export interface ScanCommandOptions {
+  workspace: string;
+  args: string[];
+  rawArgs: string[];
+}
+
+type ScanSecretsReport = {
+  kind: 'SecretsScanReport.v1';
+  schema_version: 1;
+  created_at: string;
+  workspace: string;
+  reportFound: boolean;
+  sourceReport: { path: string; created_at: string } | null;
+  redactions: RedactionAuditReportV1['redactions'];
+};
+
+const REDACTION_AUDIT_ROOT = path.join('state', 'audits', 'librarian', 'redaction');
+
+export async function scanCommand(options: ScanCommandOptions): Promise<void> {
+  const { workspace, rawArgs } = options;
+  const { values } = parseArgs({
+    args: rawArgs,
+    options: {
+      secrets: { type: 'boolean', default: false },
+      json: { type: 'boolean', default: false },
+      format: { type: 'string' },
+    },
+    allowPositionals: true,
+    strict: false,
+  });
+
+  if (!values.secrets) {
+    throw new CliError('Use --secrets to run secret redaction scan reporting.', 'INVALID_ARGUMENT');
+  }
+
+  const format = values.json || values.format === 'json' ? 'json' : 'text';
+  const workspaceRoot = path.resolve(workspace);
+  const latest = await readLatestRedactionReport(workspaceRoot);
+
+  const payload: ScanSecretsReport = {
+    kind: 'SecretsScanReport.v1',
+    schema_version: 1,
+    created_at: new Date().toISOString(),
+    workspace: workspaceRoot,
+    reportFound: Boolean(latest),
+    sourceReport: latest
+      ? {
+          path: latest.path,
+          created_at: latest.report.created_at,
+        }
+      : null,
+    redactions: latest?.report.redactions ?? createEmptyRedactionCounts(),
+  };
+
+  if (format === 'json') {
+    console.log(JSON.stringify(payload));
+    return;
+  }
+
+  console.log('Secrets Scan');
+  console.log('============\n');
+  console.log(`Workspace: ${workspaceRoot}`);
+  if (payload.reportFound && payload.sourceReport) {
+    console.log(`Source report: ${path.relative(workspaceRoot, payload.sourceReport.path)}`);
+    console.log(`Report created: ${payload.sourceReport.created_at}`);
+  } else {
+    console.log('Source report: none found');
+    console.log('Run librarian bootstrap/index to generate redaction audit artifacts.');
+  }
+  console.log(`\nTotal redactions: ${payload.redactions.total}`);
+  for (const [type, count] of Object.entries(payload.redactions.by_type)) {
+    console.log(`  ${type}: ${count}`);
+  }
+}
+
+async function readLatestRedactionReport(workspaceRoot: string): Promise<{ path: string; report: RedactionAuditReportV1 } | null> {
+  const auditRoot = path.join(workspaceRoot, REDACTION_AUDIT_ROOT);
+  let entries: string[];
+  try {
+    entries = await fs.readdir(auditRoot);
+  } catch {
+    return null;
+  }
+
+  let latest: { path: string; report: RedactionAuditReportV1; createdAtMs: number } | null = null;
+  for (const entry of entries) {
+    const reportPath = path.join(auditRoot, entry, 'RedactionAuditReport.v1.json');
+    let raw: string;
+    try {
+      raw = await fs.readFile(reportPath, 'utf8');
+    } catch {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    if (!isRedactionAuditReport(parsed)) continue;
+    const createdAtMs = Date.parse(parsed.created_at);
+    if (Number.isNaN(createdAtMs)) continue;
+    if (!latest || createdAtMs > latest.createdAtMs) {
+      latest = { path: reportPath, report: parsed, createdAtMs };
+    }
+  }
+
+  return latest ? { path: latest.path, report: latest.report } : null;
+}
+
+function isRedactionAuditReport(value: unknown): value is RedactionAuditReportV1 {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  if (record.kind !== 'RedactionAuditReport.v1') return false;
+  if (typeof record.created_at !== 'string') return false;
+  if (!record.redactions || typeof record.redactions !== 'object') return false;
+  const redactions = record.redactions as Record<string, unknown>;
+  if (typeof redactions.total !== 'number') return false;
+  if (!redactions.by_type || typeof redactions.by_type !== 'object') return false;
+  return true;
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -29,6 +29,7 @@ COMMANDS:
     eject-docs          Remove injected librarian docs from CLAUDE.md files
     check-providers     Check provider availability and authentication
     watch               Watch for file changes and auto-reindex
+    scan                Show security redaction scan results
     compose             Compose construction pipelines or technique bundles
     doctor              Run diagnostics and recovery hints
     health              Show current LiBrainian health status
@@ -50,6 +51,7 @@ ADVANCED:
     replay              Replay an evolution cycle or variant
     index --force ...        Incrementally index explicit files or git-selected changes
     update              Hook-friendly alias for incremental index updates
+    scan --secrets      Report secret redaction audit totals
     analyze             Run static analysis (dead code, complexity)
     config heal         Auto-detect and fix suboptimal configuration
     ralph               Run DETECT->FIX->VERIFY loop and write an audit report
@@ -896,6 +898,29 @@ EXAMPLES:
     librarian update --staged
     librarian update src/auth/session.ts src/api/mcp.ts
     librarian update --since origin/main
+`,
+
+  scan: `
+librarian scan - Security redaction scan reporting
+
+USAGE:
+    librarian scan --secrets [options]
+
+OPTIONS:
+    --secrets           Report secret redaction totals from latest audit report
+    --json              Emit machine-readable JSON output
+    --format text|json  Output format (default: text)
+
+DESCRIPTION:
+    Reports redaction totals captured by LiBrainian's secret-redaction pipeline.
+    This command reads the latest:
+      state/audits/librarian/redaction/*/RedactionAuditReport.v1.json
+
+    and prints total redactions plus per-type counts.
+
+EXAMPLES:
+    librarian scan --secrets
+    librarian scan --secrets --json
 `,
 
   analyze: `

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,7 @@
  *   librarian journey             - Run agentic journey simulations
  *   librarian live-fire           - Run continuous objective trial matrix
  *   librarian watch               - Watch for file changes and auto-reindex
+ *   librarian scan --secrets      - Show secret redaction scan totals
  *   librarian contract            - Show system contract and provenance
  *   librarian diagnose            - Diagnose Librarian self-knowledge drift
  *   librarian health              - Show health status (EvolutionOps)
@@ -65,6 +66,7 @@ import { evalCommand } from './commands/eval.js';
 import { replayCommand } from './commands/replay.js';
 import { watchCommand } from './commands/watch.js';
 import { indexCommand } from './commands/index.js';
+import { scanCommand } from './commands/scan.js';
 import { contractCommand } from './commands/contract.js';
 import { diagnoseCommand } from './commands/diagnose.js';
 import { composeCommand } from './commands/compose.js';
@@ -87,7 +89,7 @@ import {
   type ErrorEnvelope,
 } from './errors.js';
 
-type Command = 'status' | 'query' | 'feedback' | 'bootstrap' | 'uninstall' | 'mcp' | 'eject-docs' | 'inspect' | 'confidence' | 'validate' | 'check-providers' | 'visualize' | 'coverage' | 'quickstart' | 'setup' | 'init' | 'smoke' | 'journey' | 'live-fire' | 'health' | 'heal' | 'evolve' | 'eval' | 'replay' | 'watch' | 'index' | 'update' | 'contract' | 'diagnose' | 'compose' | 'analyze' | 'config' | 'doctor' | 'publish-gate' | 'ralph' | 'external-repos' | 'help';
+type Command = 'status' | 'query' | 'feedback' | 'bootstrap' | 'uninstall' | 'mcp' | 'eject-docs' | 'inspect' | 'confidence' | 'validate' | 'check-providers' | 'visualize' | 'coverage' | 'quickstart' | 'setup' | 'init' | 'smoke' | 'journey' | 'live-fire' | 'health' | 'heal' | 'evolve' | 'eval' | 'replay' | 'watch' | 'index' | 'update' | 'scan' | 'contract' | 'diagnose' | 'compose' | 'analyze' | 'config' | 'doctor' | 'publish-gate' | 'ralph' | 'external-repos' | 'help';
 
 /**
  * Check if --json flag is present in arguments
@@ -225,6 +227,10 @@ const COMMANDS: Record<Command, { description: string; usage: string }> = {
   'index': {
     description: 'Incrementally index specific files (no full bootstrap)',
     usage: 'librarian index --force <file...>|--incremental|--staged|--since <ref> [--verbose]',
+  },
+  'scan': {
+    description: 'Scan/redaction audit reporting for sensitive content',
+    usage: 'librarian scan --secrets [--json|--format text|json]',
   },
   'update': {
     description: 'Hook-friendly alias for incremental indexing (implies --force)',
@@ -518,6 +524,13 @@ async function main(): Promise<void> {
             since: since ?? undefined,
           });
         }
+        break;
+      case 'scan':
+        await scanCommand({
+          workspace,
+          args: commandArgs,
+          rawArgs: args,
+        });
         break;
       case 'analyze':
         await analyzeCommand({


### PR DESCRIPTION
## Summary
- add `librarian scan --secrets` command for non-interactive secret redaction audit reporting
- wire scan command into CLI dispatch + help output and document CI usage in README
- expand token redaction detector to include GitHub token patterns (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`)
- add tests for scan command behavior and redaction coverage

## Validation
- `npm test -- --run src/cli/commands/__tests__/scan.test.ts src/__tests__/librarian.test.ts src/cli/__tests__/help_exit_codes.test.ts`
- `npm test -- --run src/mcp/__tests__/schema.test.ts src/mcp/__tests__/query_and_bundle_pagination.test.ts src/mcp/__tests__/request_human_review.test.ts`

Closes #262
