### PR TITLE
feat(mcp): add find_symbol id discovery tool

### DIFF
--- a/src/mcp/__tests__/find_symbol.test.ts
+++ b/src/mcp/__tests__/find_symbol.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createLibrarianMCPServer } from '../server.js';
+
+describe('MCP find_symbol tool', () => {
+  it('discovers claim IDs for verify_claim', async () => {
+    const server = await createLibrarianMCPServer({
+      authorization: { enabledScopes: ['read'], requireConsent: false },
+    });
+
+    const workspace = '/tmp/workspace';
+    const storage = {
+      getContextPacks: vi.fn().mockResolvedValue([
+        {
+          packId: 'claim-auth-1',
+          packType: 'function_context',
+          targetId: 'src/auth.ts::verifyToken',
+          summary: 'Validate auth token signature and expiry',
+          keyFacts: ['Token verification', 'JWT expiry check'],
+          relatedFiles: ['src/auth.ts'],
+        },
+      ]),
+      getFunctionsByName: vi.fn().mockResolvedValue([]),
+      getFunctions: vi.fn().mockResolvedValue([]),
+      getModules: vi.fn().mockResolvedValue([]),
+    };
+
+    server.registerWorkspace(workspace);
+    server.updateWorkspaceState(workspace, { indexState: 'ready' });
+    (server as any).getOrCreateStorage = vi.fn().mockResolvedValue(storage);
+
+    const result = await (server as any).executeFindSymbol({
+      workspace,
+      query: 'auth token',
+      kind: 'claim',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]?.id).toBe('claim-auth-1');
+    expect(result.matches[0]?.kind).toBe('claim');
+  });
+
+  it('returns function, composition, and run matches when kind is omitted', async () => {
+    const server = await createLibrarianMCPServer({
+      authorization: { enabledScopes: ['read'], requireConsent: false },
+    });
+
+    const workspace = '/tmp/workspace';
+    const storage = {
+      getContextPacks: vi.fn().mockResolvedValue([]),
+      getFunctionsByName: vi.fn().mockResolvedValue([
+        {
+          id: 'fn-auth-1',
+          name: 'authenticateUser',
+          signature: 'authenticateUser(token: string): boolean',
+          filePath: 'src/auth.ts',
+          purpose: 'Authenticate session token',
+        },
+      ]),
+      getFunctions: vi.fn().mockResolvedValue([]),
+      getModules: vi.fn().mockResolvedValue([]),
+    };
+
+    const mockLibrarian = {
+      listTechniqueCompositions: vi.fn().mockResolvedValue([
+        {
+          id: 'tc_auth_review',
+          name: 'Auth Review',
+          description: 'Authentication review composition',
+          primitiveIds: ['tp_verify_claim'],
+        },
+      ]),
+    };
+
+    server.registerWorkspace(workspace);
+    server.updateWorkspaceState(workspace, { indexState: 'ready', librarian: mockLibrarian as any });
+    (server as any).getOrCreateStorage = vi.fn().mockResolvedValue(storage);
+    (server as any).getBootstrapRunHistory = vi.fn().mockResolvedValue([
+      {
+        runId: 'run-auth-1',
+        workspace,
+        startedAt: '2026-02-19T00:00:00.000Z',
+        success: true,
+        durationMs: 1000,
+        stats: {
+          filesProcessed: 1,
+          functionsIndexed: 1,
+          contextPacksCreated: 1,
+          averageConfidence: 0.9,
+        },
+      },
+    ]);
+
+    const result = await (server as any).executeFindSymbol({
+      workspace,
+      query: 'auth',
+      limit: 10,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.matches.some((match: any) => match.id === 'fn-auth-1' && match.kind === 'function')).toBe(true);
+    expect(result.matches.some((match: any) => match.id === 'tc_auth_review' && match.kind === 'composition')).toBe(true);
+    expect(result.matches.some((match: any) => match.id === 'run-auth-1' && match.kind === 'run')).toBe(true);
+    expect(result.matches[0]?.id).toBe('fn-auth-1');
+  });
+});

--- a/src/mcp/__tests__/schema.test.ts
+++ b/src/mcp/__tests__/schema.test.ts
@@ -26,6 +26,7 @@ import {
   DiffRunsToolInputSchema,
   ExportIndexToolInputSchema,
   GetContextPackBundleToolInputSchema,
+  FindSymbolToolInputSchema,
   queryToolJsonSchema,
   type ToolName,
 } from '../schema.js';
@@ -41,6 +42,7 @@ import {
   isDiffRunsToolInput,
   isExportIndexToolInput,
   isGetContextPackBundleToolInput,
+  isFindSymbolToolInput,
 } from '../types.js';
 
 describe('MCP Schema', () => {
@@ -76,7 +78,8 @@ describe('MCP Schema', () => {
       expect(schemas).toContain('compile_technique_composition');
       expect(schemas).toContain('compile_intent_bundles');
       expect(schemas).toContain('get_change_impact');
-      expect(schemas).toHaveLength(22);
+      expect(schemas).toContain('find_symbol');
+      expect(schemas).toHaveLength(23);
     });
 
     it('should return schema for known tools', () => {
@@ -360,6 +363,40 @@ describe('MCP Schema', () => {
     it('should pass type guard', () => {
       expect(isVerifyClaimToolInput({ claimId: 'test' })).toBe(true);
       expect(isVerifyClaimToolInput({})).toBe(false);
+    });
+  });
+
+  describe('Find Symbol Tool Schema', () => {
+    it('should validate required fields', () => {
+      const result = validateToolInput('find_symbol', {
+        query: 'authenticateUser',
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it('should validate optional fields', () => {
+      const result = validateToolInput('find_symbol', {
+        query: 'auth token',
+        kind: 'claim',
+        workspace: '/tmp/workspace',
+        limit: 10,
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject invalid kind and limit', () => {
+      expect(validateToolInput('find_symbol', { query: 'x', kind: 'invalid' }).valid).toBe(false);
+      expect(validateToolInput('find_symbol', { query: 'x', limit: 0 }).valid).toBe(false);
+    });
+
+    it('should pass type guard', () => {
+      expect(isFindSymbolToolInput({ query: 'auth' })).toBe(true);
+      expect(isFindSymbolToolInput({ query: 'auth', kind: 'function', limit: 20 })).toBe(true);
+      expect(isFindSymbolToolInput({})).toBe(false);
+    });
+
+    it('exports FindSymbolToolInputSchema', () => {
+      expect(FindSymbolToolInputSchema).toBeDefined();
     });
   });
 

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -3,7 +3,7 @@
  *
  * This module provides the MCP server implementation for Librarian:
  * - Resources: file tree, symbols, knowledge maps, method packs, audits, provenance, identity
- * - Tools: bootstrap, status, system_contract, diagnose_self, query, verify_claim, run_audit, diff_runs, export_index, get_context_pack_bundle, list_*, compile_*
+ * - Tools: bootstrap, status, system_contract, diagnose_self, query, find_symbol, verify_claim, run_audit, diff_runs, export_index, get_context_pack_bundle, list_*, compile_*
  * - Authorization and consent hooks
  * - Audit trail integration
  *
@@ -45,6 +45,10 @@ export {
   type QueryToolOutput,
   type ContextPackSummary,
   type EvidenceSummary,
+  type FindSymbolKind,
+  type FindSymbolMatch,
+  type FindSymbolToolInput,
+  type FindSymbolToolOutput,
   type VerifyClaimToolInput,
   type VerifyClaimToolOutput,
   type RunAuditToolInput,
@@ -71,6 +75,7 @@ export {
   // Type guards
   isBootstrapToolInput,
   isQueryToolInput,
+  isFindSymbolToolInput,
   isVerifyClaimToolInput,
   isRunAuditToolInput,
   isListRunsToolInput,
@@ -97,6 +102,7 @@ export {
   SystemContractToolInputSchema,
   DiagnoseSelfToolInputSchema,
   QueryToolInputSchema,
+  FindSymbolToolInputSchema,
   VerifyClaimToolInputSchema,
   RunAuditToolInputSchema,
   ListRunsToolInputSchema,

--- a/src/mcp/schema.ts
+++ b/src/mcp/schema.ts
@@ -40,6 +40,16 @@ export const AuditTypeSchema = z.enum(['full', 'claims', 'coverage', 'security',
 /** Bundle type options */
 export const BundleTypeSchema = z.enum(['minimal', 'standard', 'comprehensive']);
 
+/** Symbol discovery kinds */
+export const FindSymbolKindSchema = z.enum([
+  'function',
+  'module',
+  'context_pack',
+  'claim',
+  'composition',
+  'run',
+]);
+
 /** Shared pagination/output controls */
 const PageSizeSchema = z.number().int().min(1).max(200);
 const PageIdxSchema = z.number().int().min(0);
@@ -135,6 +145,16 @@ export const RequestHumanReviewToolInputSchema = z.object({
 export const VerifyClaimToolInputSchema = z.object({
   claimId: z.string().min(1).describe('ID of the claim to verify'),
   force: z.boolean().optional().default(false).describe('Force re-verification even if recently verified'),
+}).strict();
+
+/**
+ * Find symbol tool input schema
+ */
+export const FindSymbolToolInputSchema = z.object({
+  query: z.string().min(1).max(500).describe('Human-readable function, module, claim, composition, or run query'),
+  kind: FindSymbolKindSchema.optional().describe('Optional category filter for symbol discovery'),
+  workspace: z.string().optional().describe('Workspace path (optional, uses first ready workspace if not specified)'),
+  limit: z.number().int().min(1).max(200).optional().default(20).describe('Maximum matches to return (default: 20, max: 200)'),
 }).strict();
 
 /**
@@ -290,6 +310,7 @@ export type SubmitFeedbackToolInputType = z.infer<typeof SubmitFeedbackToolInput
 export type ResetSessionStateToolInputType = z.infer<typeof ResetSessionStateToolInputSchema>;
 export type RequestHumanReviewToolInputType = z.infer<typeof RequestHumanReviewToolInputSchema>;
 export type VerifyClaimToolInputType = z.infer<typeof VerifyClaimToolInputSchema>;
+export type FindSymbolToolInputType = z.infer<typeof FindSymbolToolInputSchema>;
 export type RunAuditToolInputType = z.infer<typeof RunAuditToolInputSchema>;
 export type ListRunsToolInputType = z.infer<typeof ListRunsToolInputSchema>;
 export type DiffRunsToolInputType = z.infer<typeof DiffRunsToolInputSchema>;
@@ -322,6 +343,7 @@ export const TOOL_INPUT_SCHEMAS = {
   get_change_impact: GetChangeImpactToolInputSchema,
   submit_feedback: SubmitFeedbackToolInputSchema,
   verify_claim: VerifyClaimToolInputSchema,
+  find_symbol: FindSymbolToolInputSchema,
   run_audit: RunAuditToolInputSchema,
   list_runs: ListRunsToolInputSchema,
   diff_runs: DiffRunsToolInputSchema,
@@ -487,6 +509,23 @@ export const requestHumanReviewToolJsonSchema: JSONSchema = {
   additionalProperties: false,
 };
 
+/** Find symbol tool JSON Schema */
+export const findSymbolToolJsonSchema: JSONSchema = {
+  $schema: JSON_SCHEMA_DRAFT,
+  $id: 'librarian://schemas/find-symbol-tool-input',
+  title: 'FindSymbolToolInput',
+  description: 'Input for find_symbol - discover opaque IDs for downstream MCP tools',
+  type: 'object',
+  properties: {
+    query: { type: 'string', description: 'Human-readable function, module, claim, composition, or run query', minLength: 1, maxLength: 500 },
+    kind: { type: 'string', enum: ['function', 'module', 'context_pack', 'claim', 'composition', 'run'], description: 'Optional category filter for symbol discovery' },
+    workspace: { type: 'string', description: 'Workspace path (optional, uses first ready workspace if not specified)' },
+    limit: { type: 'number', description: 'Maximum matches to return (default: 20, max: 200)', minimum: 1, maximum: 200, default: 20 },
+  },
+  required: ['query'],
+  additionalProperties: false,
+};
+
 /** All JSON schemas */
 export const JSON_SCHEMAS: Record<string, JSONSchema> = {
   bootstrap: bootstrapToolJsonSchema,
@@ -495,6 +534,7 @@ export const JSON_SCHEMAS: Record<string, JSONSchema> = {
   request_human_review: requestHumanReviewToolJsonSchema,
   get_change_impact: getChangeImpactToolJsonSchema,
   submit_feedback: submitFeedbackToolJsonSchema,
+  find_symbol: findSymbolToolJsonSchema,
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- add MCP `find_symbol` tool to discover opaque IDs (`claimId`, `entityIds`, `compositionId`, `runId`) from human-readable queries
- wire the tool through schema validation, type guards, authorization, tool registry metadata, and MCP module exports
- implement ranked discovery across functions, modules, context packs/claims, technique compositions, and bootstrap runs
- update dependent tool descriptions (`verify_claim`, `get_context_pack_bundle`, `compile_technique_composition`, `diff_runs`) to explicitly reference `find_symbol` as the discovery step
- add tests for schema/type-guard coverage and end-to-end MCP tool behavior

## Validation
- `npm test -- --run src/mcp/__tests__/schema.test.ts src/mcp/__tests__/find_symbol.test.ts src/mcp/__tests__/tool_registry_consistency.test.ts src/mcp/__tests__/authentication.test.ts`
- `npm test -- --run src/mcp/__tests__`
- `npx tsc --noEmit`

Closes #111
