### PR TITLE
feat(mcp): add synthesize_plan tool and session plan tracking

### DIFF
--- a/src/mcp/__tests__/schema.test.ts
+++ b/src/mcp/__tests__/schema.test.ts
@@ -18,6 +18,7 @@ import {
   safeParseToolInput,
   BootstrapToolInputSchema,
   QueryToolInputSchema,
+  SynthesizePlanToolInputSchema,
   ResetSessionStateToolInputSchema,
   RequestHumanReviewToolInputSchema,
   SubmitFeedbackToolInputSchema,
@@ -37,6 +38,7 @@ import {
   MCP_SCHEMA_VERSION,
   isBootstrapToolInput,
   isQueryToolInput,
+  isSynthesizePlanToolInput,
   isResetSessionStateToolInput,
   isRequestHumanReviewToolInput,
   isSubmitFeedbackToolInput,
@@ -67,6 +69,7 @@ describe('MCP Schema', () => {
       expect(schemas).toContain('diagnose_self');
       expect(schemas).toContain('status');
       expect(schemas).toContain('query');
+      expect(schemas).toContain('synthesize_plan');
       expect(schemas).toContain('reset_session_state');
       expect(schemas).toContain('request_human_review');
       expect(schemas).toContain('submit_feedback');
@@ -88,7 +91,7 @@ describe('MCP Schema', () => {
       expect(schemas).toContain('compile_intent_bundles');
       expect(schemas).toContain('get_change_impact');
       expect(schemas).toContain('find_symbol');
-      expect(schemas).toHaveLength(26);
+      expect(schemas).toHaveLength(27);
     });
 
     it('should return schema for known tools', () => {
@@ -344,6 +347,38 @@ describe('MCP Schema', () => {
       expect(isResetSessionStateToolInput({ sessionId: 'sess_123' })).toBe(true);
       expect(isResetSessionStateToolInput({ workspace: '/tmp/workspace' })).toBe(true);
       expect(isResetSessionStateToolInput(null)).toBe(false);
+    });
+  });
+
+  describe('Synthesize Plan Tool Schema', () => {
+    it('should validate required fields', () => {
+      const result = validateToolInput('synthesize_plan', {
+        task: 'Stabilize auth token refresh flow',
+        context_pack_ids: ['pack-auth-1', 'pack-auth-2'],
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject missing required fields', () => {
+      expect(validateToolInput('synthesize_plan', {
+        task: 'Missing packs',
+      }).valid).toBe(false);
+
+      expect(validateToolInput('synthesize_plan', {
+        context_pack_ids: ['pack-auth-1'],
+      }).valid).toBe(false);
+    });
+
+    it('should pass type guard', () => {
+      expect(isSynthesizePlanToolInput({
+        task: 'Investigate auth race',
+        context_pack_ids: ['pack-1'],
+      })).toBe(true);
+      expect(isSynthesizePlanToolInput({
+        task: 'Invalid empty packs',
+        context_pack_ids: [],
+      })).toBe(false);
+      expect(SynthesizePlanToolInputSchema).toBeDefined();
     });
   });
 

--- a/src/mcp/__tests__/synthesize_plan.test.ts
+++ b/src/mcp/__tests__/synthesize_plan.test.ts
@@ -1,0 +1,74 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { createLibrarianMCPServer } from '../server.js';
+
+describe('MCP synthesize_plan tool', () => {
+  it('creates a plan entry and appends audit log event', async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'librarian-synthesize-plan-'));
+
+    try {
+      const server = await createLibrarianMCPServer({
+        authorization: { enabledScopes: ['read', 'write'], requireConsent: false },
+        audit: { enabled: false, logPath: '.librarian/audit/mcp', retentionDays: 1 },
+      });
+      server.registerWorkspace(workspace);
+      server.updateWorkspaceState(workspace, { indexState: 'ready' });
+
+      const result = await (server as any).executeSynthesizePlan({
+        task: 'Stabilize auth token refresh race conditions',
+        context_pack_ids: ['pack-auth-1', 'pack-auth-2'],
+        workspace,
+        sessionId: 'sess-plan-1',
+      });
+
+      expect(result.plan_id).toMatch(/^plan_/);
+      expect(result.context_used).toEqual(['pack-auth-1', 'pack-auth-2']);
+      expect(String(result.plan)).toContain('Stabilize auth token refresh race conditions');
+
+      const auditPath = path.join(workspace, '.librainian', 'audit-log.jsonl');
+      const auditContent = await fs.readFile(auditPath, 'utf8');
+      const lines = auditContent.trim().split('\n');
+      expect(lines.length).toBeGreaterThan(0);
+      const entry = JSON.parse(lines[lines.length - 1] ?? '{}');
+      expect(entry.event).toBe('synthesize_plan');
+      expect(entry.plan_id).toBe(result.plan_id);
+      expect(entry.task).toContain('Stabilize auth token refresh');
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('retrieves a stored plan by plan_id via status', async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'librarian-synthesize-status-'));
+
+    try {
+      const server = await createLibrarianMCPServer({
+        authorization: { enabledScopes: ['read', 'write'], requireConsent: false },
+        audit: { enabled: false, logPath: '.librarian/audit/mcp', retentionDays: 1 },
+      });
+      server.registerWorkspace(workspace);
+      server.updateWorkspaceState(workspace, { indexState: 'ready' });
+
+      const planResult = await (server as any).executeSynthesizePlan({
+        task: 'Plan API-safe session refactor',
+        context_pack_ids: ['pack-api-1'],
+        workspace,
+        sessionId: 'sess-plan-lookup',
+      });
+
+      const statusResult = await (server as any).executeStatus({
+        workspace,
+        sessionId: 'sess-plan-lookup',
+        planId: planResult.plan_id,
+      });
+
+      expect(statusResult.planTracking?.planById?.plan_id).toBe(planResult.plan_id);
+      expect(statusResult.planTracking?.planById?.task).toBe('Plan API-safe session refactor');
+      expect(statusResult.planTracking?.planById?.context_used).toEqual(['pack-api-1']);
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/mcp/schema.ts
+++ b/src/mcp/schema.ts
@@ -161,6 +161,16 @@ export const ResetSessionStateToolInputSchema = z.object({
 }).strict().default({});
 
 /**
+ * Synthesize plan tool input schema
+ */
+export const SynthesizePlanToolInputSchema = z.object({
+  task: z.string().min(1).max(2000).describe('Task description the agent is planning to execute'),
+  context_pack_ids: z.array(z.string().min(1)).min(1).max(100).describe('Context pack IDs from prior retrieval that informed the plan'),
+  workspace: z.string().optional().describe('Workspace path (optional, uses first available if not specified)'),
+  sessionId: z.string().min(1).optional().describe('Optional session identifier used to persist and retrieve plan state'),
+}).strict();
+
+/**
  * Request human review tool input schema
  */
 export const RequestHumanReviewToolInputSchema = z.object({
@@ -330,6 +340,8 @@ export const DiagnoseSelfToolInputSchema = z.object({
  */
 export const StatusToolInputSchema = z.object({
   workspace: z.string().optional().describe('Workspace path (optional, uses first available if not specified)'),
+  sessionId: z.string().min(1).optional().describe('Optional session identifier used for session-scoped status details'),
+  planId: z.string().min(1).optional().describe('Optional plan ID to retrieve a specific synthesized plan'),
 }).strict();
 
 // ============================================================================
@@ -338,6 +350,7 @@ export const StatusToolInputSchema = z.object({
 
 export type BootstrapToolInputType = z.infer<typeof BootstrapToolInputSchema>;
 export type QueryToolInputType = z.infer<typeof QueryToolInputSchema>;
+export type SynthesizePlanToolInputType = z.infer<typeof SynthesizePlanToolInputSchema>;
 export type GetChangeImpactToolInputType = z.infer<typeof GetChangeImpactToolInputSchema>;
 export type SubmitFeedbackToolInputType = z.infer<typeof SubmitFeedbackToolInputSchema>;
 export type ExplainFunctionToolInputType = z.infer<typeof ExplainFunctionToolInputSchema>;
@@ -374,6 +387,7 @@ export const TOOL_INPUT_SCHEMAS = {
   diagnose_self: DiagnoseSelfToolInputSchema,
   status: StatusToolInputSchema,
   query: QueryToolInputSchema,
+  synthesize_plan: SynthesizePlanToolInputSchema,
   explain_function: ExplainFunctionToolInputSchema,
   find_usages: FindUsagesToolInputSchema,
   trace_imports: TraceImportsToolInputSchema,
@@ -580,6 +594,23 @@ export const resetSessionStateToolJsonSchema: JSONSchema = {
   additionalProperties: false,
 };
 
+/** Synthesize plan tool JSON Schema */
+export const synthesizePlanToolJsonSchema: JSONSchema = {
+  $schema: JSON_SCHEMA_DRAFT,
+  $id: 'librarian://schemas/synthesize-plan-tool-input',
+  title: 'SynthesizePlanToolInput',
+  description: 'Input for synthesize_plan - persist an explicit task plan grounded in retrieved context packs',
+  type: 'object',
+  properties: {
+    task: { type: 'string', description: 'Task description the agent is planning to execute', minLength: 1, maxLength: 2000 },
+    context_pack_ids: { type: 'array', items: { type: 'string' }, description: 'Context pack IDs that informed the plan', minItems: 1 },
+    workspace: { type: 'string', description: 'Workspace path (optional, uses first available if not specified)' },
+    sessionId: { type: 'string', description: 'Optional session identifier used to persist and retrieve plan state', minLength: 1 },
+  },
+  required: ['task', 'context_pack_ids'],
+  additionalProperties: false,
+};
+
 /** Request human review tool JSON Schema */
 export const requestHumanReviewToolJsonSchema: JSONSchema = {
   $schema: JSON_SCHEMA_DRAFT,
@@ -623,6 +654,7 @@ export const JSON_SCHEMAS: Record<string, JSONSchema> = {
   explain_function: explainFunctionToolJsonSchema,
   find_usages: findUsagesToolJsonSchema,
   trace_imports: traceImportsToolJsonSchema,
+  synthesize_plan: synthesizePlanToolJsonSchema,
   reset_session_state: resetSessionStateToolJsonSchema,
   request_human_review: requestHumanReviewToolJsonSchema,
   get_change_impact: getChangeImpactToolJsonSchema,


### PR DESCRIPTION
## Summary
- add new MCP tool `synthesize_plan` with schema/type guards and server execution
- persist session plan history and expose plan tracking through `status`
- append structured workspace audit events for synthesized plans
- clear plan history via `reset_session_state`
- add coverage for schema and end-to-end synthesize plan behavior

## Validation
- npm test -- --run
- npx tsc --noEmit

Closes #122
