### PR TITLE
Fix #466: add E2E acceptance gate and PR CI enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,26 @@ jobs:
       - name: Fast staged validation
         run: npm run validate:fast
 
+  e2e-acceptance:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: E2E acceptance gate
+        run: npm run test:e2e:acceptance
+
   full-tier0:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ### The plug-in intelligence layer for serious coding agents
 
 [![CI](https://github.com/nateschmiedehaus/LiBrainian/actions/workflows/ci.yml/badge.svg)](https://github.com/nateschmiedehaus/LiBrainian/actions/workflows/ci.yml)
+[![E2E tests](https://img.shields.io/github/actions/workflow/status/nateschmiedehaus/LiBrainian/ci.yml?branch=main&label=E2E%20tests)](https://github.com/nateschmiedehaus/LiBrainian/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/librainian.svg)](https://www.npmjs.com/package/librainian)
 [![npm downloads](https://img.shields.io/npm/dm/librainian.svg)](https://www.npmjs.com/package/librainian)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "test:evaluation": "node scripts/run-with-tmpdir.mjs --set LIBRARIAN_TEST_MODE=evaluation -- vitest",
     "test:heavy": "node scripts/run-with-tmpdir.mjs --set LIBRARIAN_TEST_MODE=heavy -- vitest",
     "test:system": "node scripts/run-with-tmpdir.mjs --set LIBRARIAN_TEST_MODE=system -- vitest",
+    "test:e2e:acceptance": "node scripts/run-with-tmpdir.mjs --set LIBRARIAN_TEST_MODE=unit -- vitest --run src/__tests__/e2e_acceptance_gate.test.ts",
     "test:sequential": "node scripts/run-with-tmpdir.mjs --set LIBRARIAN_TEST_WORKERS=1 -- vitest",
     "test:conservative": "node scripts/run-with-tmpdir.mjs --set LIBRARIAN_RESOURCE_MODE=conservative -- vitest",
     "test:tier0": "npm test -- --run",

--- a/src/__tests__/e2e_acceptance_gate.test.ts
+++ b/src/__tests__/e2e_acceptance_gate.test.ts
@@ -1,0 +1,215 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as fsSync from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { bootstrapProject } from '../api/bootstrap.js';
+import { queryLibrarian } from '../api/query.js';
+import { createSqliteStorage } from '../storage/sqlite_storage.js';
+import { createLibrarianMCPServer } from '../mcp/server.js';
+import type { LibrarianStorage, GraphEdge } from '../storage/types.js';
+import type { EmbeddingRequest, EmbeddingResult } from '../api/embeddings.js';
+
+const E2E_FIXTURE_PATH = path.resolve(__dirname, '../../tests/fixtures/e2e-fixture');
+
+function resultContainsPath(result: { packs?: Array<{ targetId?: string; relatedFiles?: string[] }> }, expectedPath: string): boolean {
+  const normalizedExpected = expectedPath.replace(/\\/g, '/').toLowerCase();
+  for (const pack of result.packs ?? []) {
+    const targetId = (pack.targetId ?? '').replace(/\\/g, '/').toLowerCase();
+    if (targetId.includes(normalizedExpected) || normalizedExpected.includes(targetId)) {
+      return true;
+    }
+    for (const related of pack.relatedFiles ?? []) {
+      const rel = related.replace(/\\/g, '/').toLowerCase();
+      if (rel.includes(normalizedExpected) || normalizedExpected.includes(rel)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+describe('E2E acceptance gate (issue #466)', () => {
+  let storage: LibrarianStorage;
+  let fixtureWorkspace = '';
+  let dbPath = '';
+  let deterministicEmbeddingService: {
+    getEmbeddingDimension: () => number;
+    generateEmbedding: (request: EmbeddingRequest) => Promise<EmbeddingResult>;
+    generateEmbeddings: (requests: EmbeddingRequest[]) => Promise<EmbeddingResult[]>;
+  };
+
+  beforeAll(async () => {
+    if (!fsSync.existsSync(E2E_FIXTURE_PATH)) {
+      throw new Error(`Fixture missing: ${E2E_FIXTURE_PATH}`);
+    }
+
+    fixtureWorkspace = path.join(os.tmpdir(), `librarian-e2e-fixture-${randomUUID()}`);
+    await fs.cp(E2E_FIXTURE_PATH, fixtureWorkspace, { recursive: true });
+    await fs.rm(path.join(fixtureWorkspace, '.librarian'), { recursive: true, force: true });
+
+    dbPath = path.join(os.tmpdir(), `librarian-e2e-gate-${randomUUID()}.db`);
+    storage = createSqliteStorage(dbPath, fixtureWorkspace);
+    await storage.initialize();
+    deterministicEmbeddingService = {
+      getEmbeddingDimension(): number {
+        return 384;
+      },
+      async generateEmbedding(request: EmbeddingRequest): Promise<EmbeddingResult> {
+        const embedding = new Float32Array(384);
+        embedding[0] = 1;
+        embedding[1] = (request.text.length % 13) / 100;
+        const magnitude = Math.hypot(...embedding);
+        embedding[0] /= magnitude;
+        embedding[1] /= magnitude;
+        return {
+          embedding,
+          modelId: 'test-e2e-deterministic-384',
+          provider: 'xenova',
+          generatedAt: new Date().toISOString(),
+          tokenCount: Math.max(1, Math.ceil(request.text.length / 4)),
+        };
+      },
+      async generateEmbeddings(requests: EmbeddingRequest[]): Promise<EmbeddingResult[]> {
+        return Promise.all(requests.map((request) => this.generateEmbedding(request)));
+      },
+    };
+
+    await bootstrapProject(
+      {
+        workspace: fixtureWorkspace,
+        bootstrapMode: 'fast',
+        include: ['**/*'],
+        exclude: ['node_modules/**', '.git/**'],
+        maxFileSizeBytes: 512_000,
+        skipProviderProbe: true,
+        embeddingService: deterministicEmbeddingService as any,
+      },
+      storage,
+    );
+  }, 120_000);
+
+  afterAll(async () => {
+    await storage?.close?.();
+    if (dbPath) {
+      await fs.rm(dbPath, { force: true });
+      await fs.rm(`${dbPath}-wal`, { force: true });
+      await fs.rm(`${dbPath}-shm`, { force: true });
+    }
+    if (fixtureWorkspace) {
+      await fs.rm(fixtureWorkspace, { recursive: true, force: true });
+    }
+  });
+
+  it('indexes known functions, builds expected call edges, and stores non-zero embeddings', async () => {
+    const functions = await storage.getFunctions();
+    const authenticateUser = functions.find((fn) => fn.name === 'authenticateUser');
+    const validateEmail = functions.find((fn) => fn.name === 'validateEmail');
+    const loadUserByEmail = functions.find((fn) => fn.name === 'loadUserByEmail');
+
+    expect(authenticateUser).toBeTruthy();
+    expect(validateEmail).toBeTruthy();
+    expect(loadUserByEmail).toBeTruthy();
+
+    const edges = await storage.getGraphEdges({ edgeType: 'calls' });
+    const hasEdge = (fromId: string, toId: string): boolean =>
+      edges.some((edge: GraphEdge) => edge.edgeType === 'calls' && edge.fromId === fromId && edge.toId === toId);
+
+    expect(hasEdge(authenticateUser!.id, validateEmail!.id)).toBe(true);
+    expect(hasEdge(authenticateUser!.id, loadUserByEmail!.id)).toBe(true);
+    expect(hasEdge(validateEmail!.id, loadUserByEmail!.id)).toBe(false);
+
+    const embedding = await storage.getEmbedding(authenticateUser!.id);
+    expect(embedding).toBeTruthy();
+    expect(Array.from(embedding ?? []).some((value) => value !== 0)).toBe(true);
+  });
+
+  it('returns auth module context with confidence and latency bounds for an orientation query', async () => {
+    const result = await queryLibrarian(
+      {
+        intent: 'where is authentication handled?',
+        depth: 'L0',
+        llmRequirement: 'disabled',
+        embeddingRequirement: 'disabled',
+      },
+      storage,
+      deterministicEmbeddingService as any,
+    );
+
+    expect(result.latencyMs).toBeLessThan(5_000);
+    expect(result.totalConfidence).toBeGreaterThan(0.5);
+    expect(resultContainsPath(result, 'src/auth/session.ts')).toBe(true);
+  });
+
+  it('serves semantic_search via MCP and returns validation module hits in MCP tool format', async () => {
+    const server = await createLibrarianMCPServer({
+      authorization: {
+        enabledScopes: ['read'],
+        requireConsent: false,
+      },
+    });
+
+    server.registerWorkspace(fixtureWorkspace);
+    server.updateWorkspaceState(fixtureWorkspace, { indexState: 'ready' });
+    (server as unknown as { getOrCreateStorage: () => Promise<LibrarianStorage> }).getOrCreateStorage = vi
+      .fn()
+      .mockResolvedValue(storage);
+
+    const toolResponse = await (server as unknown as {
+      callTool: (name: string, args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+    }).callTool('semantic_search', {
+      query: 'find user validation',
+      workspace: fixtureWorkspace,
+      depth: 'L1',
+      minConfidence: 0.2,
+    });
+
+    expect(toolResponse.isError).not.toBe(true);
+    expect(Array.isArray(toolResponse.content)).toBe(true);
+    const payload = JSON.parse(toolResponse.content[0]?.text ?? '{}') as Record<string, unknown>;
+    expect(payload.tool).toBe('semantic_search');
+    expect(Array.isArray(payload.packs)).toBe(true);
+    expect(JSON.stringify(payload).toLowerCase()).toContain('validation/user.ts');
+  });
+
+  it('round-trips get_context_pack under 10k tokens and includes auth-related function context', async () => {
+    const server = await createLibrarianMCPServer({
+      authorization: {
+        enabledScopes: ['read'],
+        requireConsent: false,
+      },
+    });
+
+    server.registerWorkspace(fixtureWorkspace);
+    server.updateWorkspaceState(fixtureWorkspace, { indexState: 'ready' });
+    (server as unknown as { getOrCreateStorage: () => Promise<LibrarianStorage> }).getOrCreateStorage = vi
+      .fn()
+      .mockResolvedValue(storage);
+
+    const toolResponse = await (server as unknown as {
+      callTool: (name: string, args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+    }).callTool('get_context_pack', {
+      intent: 'authentication module flow',
+      workspace: fixtureWorkspace,
+      relevantFiles: [path.join(fixtureWorkspace, 'src/auth/session.ts')],
+      tokenBudget: 10_000,
+    });
+
+    expect(toolResponse.isError).not.toBe(true);
+    const payload = JSON.parse(toolResponse.content[0]?.text ?? '{}') as {
+      success?: boolean;
+      tool?: string;
+      tokenCount?: number;
+      functions?: Array<{ relatedFiles?: string[] }>;
+    };
+    expect(payload.success).toBe(true);
+    expect(payload.tool).toBe('get_context_pack');
+    expect(payload.tokenCount ?? 0).toBeLessThan(10_000);
+    expect(Array.isArray(payload.functions)).toBe(true);
+    expect(
+      (payload.functions ?? []).some((fn) =>
+        (fn.relatedFiles ?? []).some((file) => file.replace(/\\/g, '/').includes('src/auth/session.ts'))),
+    ).toBe(true);
+  });
+});

--- a/src/agents/__tests__/index_librarian_multi_vector.test.ts
+++ b/src/agents/__tests__/index_librarian_multi_vector.test.ts
@@ -106,7 +106,7 @@ describe('IndexLibrarian - storeMultiVectorEmbedding validation', () => {
 
       expect(mockStorage.upsertMultiVector).toHaveBeenCalledWith(
         expect.objectContaining({
-          entityId: module.path,
+          entityId: module.id,
           entityType: 'module',
           modelId: 'all-MiniLM-L6-v2',
         })

--- a/src/agents/index_librarian.ts
+++ b/src/agents/index_librarian.ts
@@ -690,7 +690,7 @@ export class IndexLibrarian implements IndexingAgent {
           const modelId = requireEmbeddingModelId(result.modelId, `function:${target.fn.id}`);
           validateEmbedding(result.embedding, this.config.embeddingDimension);
           functionEmbeddings.push({
-            entityId: `${target.fn.filePath}:${target.fn.name}`,
+            entityId: target.fn.id,
             embedding: result.embedding,
             metadata: {
               modelId,
@@ -756,7 +756,7 @@ export class IndexLibrarian implements IndexingAgent {
             const modelId = requireEmbeddingModelId(result.modelId, `module:${module.id}`);
             validateEmbedding(result.embedding, this.config.embeddingDimension);
             moduleEmbedding = {
-              entityId: module.path,
+              entityId: module.id,
               embedding: result.embedding,
               metadata: {
                 modelId,
@@ -1510,7 +1510,7 @@ export class IndexLibrarian implements IndexingAgent {
       );
       this.governor?.recordTokens(tokenCount);
       return {
-        entityId: module.path,
+        entityId: module.id,
         entityType: 'module',
         payload,
         modelId: payload.modelId ?? modelId,

--- a/src/api/task_planning.ts
+++ b/src/api/task_planning.ts
@@ -427,7 +427,7 @@ async function findRelevantContext(
         file: fn.filePath,
         relevance: `Function ${fn.name}: ${fn.purpose}`,
         score: relevance,
-        entityId: `${fn.filePath}:${fn.name}`,
+        entityId: fn.id,
         entityType: 'function',
       });
     }
@@ -445,7 +445,7 @@ async function findRelevantContext(
         file: mod.path,
         relevance: `Module: ${mod.purpose}`,
         score: relevance,
-        entityId: mod.path,
+        entityId: mod.id,
         entityType: 'module',
       });
     }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1759,7 +1759,7 @@ export class LibrarianMCPServer {
       },
       {
         name: 'harvest_session_knowledge',
-        description: 'Summarize high-confidence claims and optionally sync them into annotated MEMORY.md via memory bridge',
+        description: 'Summarize high-confidence session claims and optionally sync them into annotated MEMORY.md via memory bridge',
         inputSchema: {
           type: 'object',
           properties: {

--- a/tests/fixtures/e2e-fixture/README.md
+++ b/tests/fixtures/e2e-fixture/README.md
@@ -1,0 +1,9 @@
+# E2E Acceptance Fixture
+
+Deterministic fixture used by LiBrainian E2E acceptance tests.
+
+Key invariants:
+- Authentication flow lives in `src/auth/session.js`.
+- Validation logic lives in `src/validation/user.js`.
+- User lookup lives in `src/user/repository.js`.
+- `authenticateUser` calls `validateEmail` and `loadUserByEmail`.

--- a/tests/fixtures/e2e-fixture/package.json
+++ b/tests/fixtures/e2e-fixture/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "librainian-e2e-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Deterministic fixture for LiBrainian E2E acceptance tests"
+}

--- a/tests/fixtures/e2e-fixture/src/auth/session.ts
+++ b/tests/fixtures/e2e-fixture/src/auth/session.ts
@@ -1,0 +1,30 @@
+import { validateEmail, validatePassword } from '../validation/user';
+import { loadUserByEmail } from '../user/repository';
+
+export interface AuthResult {
+  ok: boolean;
+  userId?: string;
+  reason?: string;
+}
+
+export async function authenticateUser(email: string, password: string): Promise<AuthResult> {
+  if (!validateEmail(email)) {
+    return { ok: false, reason: 'invalid_email' };
+  }
+  if (!validatePassword(password)) {
+    return { ok: false, reason: 'invalid_password' };
+  }
+
+  const user = await loadUserByEmail(email);
+  if (!user) {
+    return { ok: false, reason: 'unknown_user' };
+  }
+  if (!user.active) {
+    return { ok: false, reason: 'inactive_user' };
+  }
+  if (user.passwordHash !== password) {
+    return { ok: false, reason: 'wrong_password' };
+  }
+
+  return { ok: true, userId: user.id };
+}

--- a/tests/fixtures/e2e-fixture/src/index.ts
+++ b/tests/fixtures/e2e-fixture/src/index.ts
@@ -1,0 +1,6 @@
+import { authenticateUser } from './auth/session';
+
+export async function loginHandler(email: string, password: string): Promise<string> {
+  const result = await authenticateUser(email, password);
+  return result.ok ? `ok:${result.userId}` : `error:${result.reason}`;
+}

--- a/tests/fixtures/e2e-fixture/src/user/repository.ts
+++ b/tests/fixtures/e2e-fixture/src/user/repository.ts
@@ -1,0 +1,22 @@
+import type { UserRecord } from './types';
+
+const USERS: UserRecord[] = [
+  {
+    id: 'u_1',
+    email: 'alex@example.com',
+    passwordHash: 'pw_alex',
+    active: true,
+  },
+  {
+    id: 'u_2',
+    email: 'sam@example.com',
+    passwordHash: 'pw_sam',
+    active: false,
+  },
+];
+
+export async function loadUserByEmail(email: string): Promise<UserRecord | null> {
+  const normalized = email.trim().toLowerCase();
+  const match = USERS.find((user) => user.email.toLowerCase() === normalized);
+  return match ?? null;
+}

--- a/tests/fixtures/e2e-fixture/src/user/types.ts
+++ b/tests/fixtures/e2e-fixture/src/user/types.ts
@@ -1,0 +1,6 @@
+export interface UserRecord {
+  id: string;
+  email: string;
+  passwordHash: string;
+  active: boolean;
+}

--- a/tests/fixtures/e2e-fixture/src/validation/user.ts
+++ b/tests/fixtures/e2e-fixture/src/validation/user.ts
@@ -1,0 +1,9 @@
+export function validateEmail(email: string): boolean {
+  if (!email || typeof email !== 'string') return false;
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+}
+
+export function validatePassword(password: string): boolean {
+  if (!password || typeof password !== 'string') return false;
+  return password.length >= 6;
+}


### PR DESCRIPTION
## Summary
- add a deterministic E2E acceptance suite covering indexing correctness, query quality, MCP semantic_search response format, and get_context_pack token budget
- commit a dedicated fixture workspace at tests/fixtures/e2e-fixture/
- add `test:e2e:acceptance` npm script and run it on every pull request via CI
- add an explicit README badge for E2E test status
- fix embedding/multivector keying to use canonical function/module IDs (instead of path-based keys) and align adjacent tests

## Validation
- npm run test:e2e:acceptance
- npm test -- --run src/agents/__tests__/index_librarian_multi_vector.test.ts src/storage/__tests__/dependency_invalidation.test.ts src/__tests__/task_planning_evaluation.test.ts
- npm test -- --run src/mcp/__tests__/schema.test.ts src/mcp/__tests__/query_and_bundle_pagination.test.ts src/mcp/__tests__/request_human_review.test.ts
- npm test -- --run (full suite: 502 passed, 5 skipped after final fix)
- npm test -- --run src/mcp/__tests__/server.test.ts src/__tests__/e2e_acceptance_gate.test.ts
- npm run typecheck

Closes #466
