### PR TITLE
fix(core): enforce uncapped github issue intake policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "test:agentic:strict": "npm run eval:ab:agentic-bugfix:codex && npm run eval:use-cases:agentic && npm run eval:live-fire:hardcore && npm run smoke:external:all && npm run eval:testing-discipline && npm run eval:testing-tracker && npm run eval:publish-gate",
     "test:agentic:strict:quick": "npm run eval:ab:agentic-bugfix:quick && npm run eval:use-cases:agentic:quick && npm run eval:live-fire:quick && npm run smoke:external:sample",
     "ground-truth:external": "node scripts/run-with-tmpdir.mjs -- tsx scripts/external-ground-truth.ts",
-    "issues:plan": "node scripts/run-with-tmpdir.mjs -- tsx scripts/issue-feedback-loop.ts --repo nateschmiedehaus/LiBrainian --state open --limit 200 --out state/plans/agent-issue-fix-plan.json",
+    "issues:plan": "node scripts/run-with-tmpdir.mjs -- tsx scripts/issue-feedback-loop.ts --repo nateschmiedehaus/LiBrainian --state open --out state/plans/agent-issue-fix-plan.json",
     "policy:pull": "node scripts/gh-flow-policy-check.mjs --mode pull",
     "policy:merge": "node scripts/gh-flow-policy-check.mjs --mode merge",
     "policy:publish": "node scripts/gh-flow-policy-check.mjs --mode publish --require-clean",

--- a/src/__tests__/package_release_scripts.test.ts
+++ b/src/__tests__/package_release_scripts.test.ts
@@ -27,6 +27,10 @@ describe('package release scripts', () => {
     expect(scripts.prepare).toBe('npm run hooks:install');
     expect(scripts['evidence:drift-check']).toBe('node scripts/run-with-tmpdir.mjs -- tsx scripts/evidence-drift-guard.ts');
     expect(scripts['evidence:sync']).toBe('npm run evidence:manifest && npm run evidence:reconcile');
+    expect(scripts['issues:plan']).toBe(
+      'node scripts/run-with-tmpdir.mjs -- tsx scripts/issue-feedback-loop.ts --repo nateschmiedehaus/LiBrainian --state open --out state/plans/agent-issue-fix-plan.json'
+    );
+    expect(scripts['issues:plan']).not.toContain('--limit');
     expect(scripts.dogfood).toBe('node scripts/dogfood-sandbox.mjs');
     expect(scripts.prepublishOnly).toContain('npm run package:assert-identity');
     expect(scripts.prepublishOnly).toContain('npm run package:assert-release-provenance');
@@ -107,6 +111,13 @@ describe('package release scripts', () => {
     expect(script).toContain("'merge'");
     expect(script).toContain('Dry run: update-branch');
     expect(script).toContain('complete repo=');
+  });
+
+  it('keeps issue planning uncapped by default', () => {
+    const scriptPath = path.join(process.cwd(), 'scripts', 'issue-feedback-loop.ts');
+    const script = fs.readFileSync(scriptPath, 'utf8');
+    expect(script).toContain("default: '0'");
+    expect(script).toContain('0 means \"no cap\"');
   });
 
   it('defines staged validation scripts for daily, PR, and release gates', () => {


### PR DESCRIPTION
Fixes #546\n\n- remove default issue cap from issues planning flow\n- treat --limit 0 as uncapped intake policy\n- fetch issues via paginated gh api path\n- lock policy with package/script regression tests\n