### PR TITLE
docs: universal integration guide for MCP, REST/OpenAPI, UTCP, A2A, Python SDK, and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,26 @@ const librarian = await createLibrarian({ workspace: process.cwd() });
 const result = await librarian.query({ intent: 'Explain the deployment pipeline' });
 ```
 
+## Integration Decision Tree
+
+Choose the path that matches your runtime:
+
+- MCP-compatible IDE/client (Claude Code, Cursor, Windsurf, Cline, Gemini CLI)
+  - `docs/integrations/mcp.md`
+- Shell automation or CI/CD
+  - `docs/integrations/cli.md`
+- OpenAPI-aware or raw HTTP toolchains
+  - `docs/integrations/rest-api.md`
+- UTCP tool bus integrations
+  - `docs/integrations/utcp.md`
+- A2A orchestration integrations
+  - `docs/integrations/a2a.md`
+- Python scripts and notebooks
+  - `docs/integrations/python-sdk.md`
+
+Universal integration hub:
+- `docs/integrations/README.md`
+
 ## Why LiBrainian
 
 | Problem | Typical agent flow | LiBrainian flow |
@@ -364,6 +384,7 @@ npx tsx examples/feedback_loop_example.ts
 - Construction testing guide: `docs/constructions/testing.md`
 - Construction migration guide: `docs/constructions/migration.md`
 - Core docs: `docs/librarian/README.md`
+- Universal integration guide: `docs/integrations/README.md`
 - MCP setup: `docs/mcp-setup.md`
 - MCP design principles: `docs/mcp-design-principles.md`
 - Query guide: `docs/librarian/query-guide.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Start here for the fastest path:
 Public docs (user-facing):
 
 - `/docs/librarian/README.md` — canonical docs entry
+- `/docs/integrations/README.md` — universal integration decision tree (MCP, CLI, OpenAPI/REST, UTCP, A2A, Python SDK)
 - `/docs/librarian/API.md` — API reference
 - `/docs/librarian/AGENT_INTEGRATION.md` — integration patterns
 - `/docs/librarian/MCP_SERVER.md` — MCP usage

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,0 +1,47 @@
+# Universal Integration Guide
+
+This guide is the entry point for integrating LiBrainian from external runtimes and agent frameworks.
+
+## Integration status
+
+| Surface | Status | Primary doc |
+| --- | --- | --- |
+| MCP | Available now | [`docs/integrations/mcp.md`](./mcp.md) |
+| CLI | Available now | [`docs/integrations/cli.md`](./cli.md) |
+| OpenAPI/REST adapter | Adapter contract (preview) | [`docs/integrations/rest-api.md`](./rest-api.md) |
+| UTCP adapter | Adapter contract (preview) | [`docs/integrations/utcp.md`](./utcp.md) |
+| A2A adapter | Adapter contract (preview) | [`docs/integrations/a2a.md`](./a2a.md) |
+| Python SDK | SDK-style bridge (preview) | [`docs/integrations/python-sdk.md`](./python-sdk.md) |
+
+## Decision Tree
+
+Which environment are you integrating from?
+
+- MCP-compatible IDE/client (Claude Code, Cursor, Windsurf, Cline, Gemini CLI)
+  - Use [`docs/integrations/mcp.md`](./mcp.md)
+- Shell scripts, CI jobs, or local automation
+  - Use [`docs/integrations/cli.md`](./cli.md)
+- Frameworks expecting OpenAPI or direct HTTP tools
+  - Use [`docs/integrations/rest-api.md`](./rest-api.md)
+- Tool routing through UTCP envelopes
+  - Use [`docs/integrations/utcp.md`](./utcp.md)
+- Agent-to-agent orchestration (A2A task envelopes)
+  - Use [`docs/integrations/a2a.md`](./a2a.md)
+- Python scripts or notebooks
+  - Use [`docs/integrations/python-sdk.md`](./python-sdk.md)
+
+## Protocol adapter architecture
+
+LiBrainian keeps one canonical contract and maps protocols to it through adapters.
+
+- Canonical contract: OpenAPI/REST request and response schema
+- Native surfaces now: CLI and MCP
+- Adapter surfaces: UTCP, A2A, Python SDK
+
+Use [`docs/integrations/protocol-adapters.md`](./protocol-adapters.md) for adapter design and compatibility rules.
+
+## Related docs
+
+- OpenClaw integration: [`docs/integrations/openclaw.md`](./openclaw.md)
+- MCP deep setup: [`docs/mcp-setup.md`](../mcp-setup.md)
+- Core agent integration patterns: [`docs/librarian/AGENT_INTEGRATION.md`](../librarian/AGENT_INTEGRATION.md)

--- a/docs/integrations/a2a.md
+++ b/docs/integrations/a2a.md
@@ -1,0 +1,54 @@
+# A2A Integration
+
+Status: adapter contract (preview).
+
+A2A integration converts agent-to-agent task envelopes into LiBrainian context queries and returns evidence-rich responses to the calling agent.
+
+## Prerequisites
+
+- An A2A runtime with task request/response hooks
+- Adapter logic that maps A2A task fields to LiBrainian query fields
+- A shared workspace mount visible to the LiBrainian side
+
+## Working example
+
+```typescript
+type A2ATask = {
+  id: string;
+  taskType: 'code_context';
+  prompt: string;
+  workspace: string;
+};
+
+type LibrarianQuery = {
+  intent: string;
+  workspace: string;
+  depth: 'L0' | 'L1' | 'L2' | 'L3';
+};
+
+export function mapA2ATaskToLibrarianQuery(task: A2ATask): LibrarianQuery {
+  return {
+    intent: task.prompt,
+    workspace: task.workspace,
+    depth: 'L2',
+  };
+}
+```
+
+## Real-world use case
+
+Use A2A when one coordinating agent delegates code-context gathering to a specialist agent that uses LiBrainian as its retrieval backend.
+
+## Troubleshooting
+
+1. Delegated agent gets low-quality context
+   - Pass task-specific prompts instead of generic "analyze codebase" instructions.
+2. Response objects are too large for A2A transport
+   - Cap pack counts or trim snippet payloads at the adapter boundary.
+3. Correlation IDs are lost
+   - Carry `task.id` through adapter metadata for end-to-end tracing.
+
+## Related tests
+
+- `src/__tests__/integration_guide_docs.test.ts`
+- `src/__tests__/agent_session_test_docs.test.ts`

--- a/docs/integrations/cli.md
+++ b/docs/integrations/cli.md
@@ -1,0 +1,42 @@
+# CLI Integration
+
+Status: available now.
+
+## Prerequisites
+
+- Node.js 18+
+- `librainian` installed locally in your project or callable with `npx`
+- A workspace with readable source files
+
+## Working example
+
+```bash
+# Fast setup + self-heal
+npx librainian quickstart --ci --json
+
+# Query from scripts/CI
+npx librainian query "Where is auth enforced?" --json --out state/librarian/query.json
+
+# Health and status checks
+npx librainian status --format json
+npx librainian health --format json
+```
+
+## Real-world use case
+
+Use CLI integration for CI pipelines, release checks, and shell-based automation where deterministic command output is required.
+
+## Troubleshooting
+
+1. Query returns empty or weak context
+   - Run `npx librainian bootstrap --force` and retry.
+2. Non-interactive runners hang on prompts
+   - Add `--ci` and machine-readable flags (`--json` or `--format json`).
+3. SQLite lock errors in shared runners
+   - Run `npx librainian doctor --heal` before retries.
+
+## Related tests
+
+- `src/cli/commands/__tests__/quickstart.test.ts`
+- `src/cli/commands/__tests__/doctor.test.ts`
+- `src/__tests__/integration_guide_docs.test.ts`

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -1,0 +1,59 @@
+# MCP Integration
+
+Status: available now.
+
+## Prerequisites
+
+- Node.js 18+
+- `librainian` CLI installed (`npm i -g librainian`) or `npx -y librainian`
+- Target workspace bootstrapped at least once
+
+## Working example
+
+```bash
+# 1) Bootstrap workspace once
+librarian bootstrap
+
+# 2) Print client config snippets
+librarian mcp --print-config --client claude --json
+
+# 3) Run MCP stdio server
+librarian mcp
+```
+
+Claude Code snippet shape:
+
+```json
+{
+  "mcpServers": {
+    "librarian": {
+      "command": "librarian",
+      "args": ["mcp", "--stdio"],
+      "env": {
+        "LIBRARIAN_WORKSPACE": "/absolute/path/to/workspace"
+      }
+    }
+  }
+}
+```
+
+## Real-world use case
+
+Use MCP when your coding agent needs tool-style access to LiBrainian context during live coding sessions without adding custom HTTP plumbing.
+
+## Troubleshooting
+
+1. `command not found: librarian`
+   - Install globally or switch launcher to `npx` with `librarian mcp --print-config --launcher npx`.
+2. Client connects but no useful context
+   - Run `librarian bootstrap` in the workspace and retry.
+3. Client fails after config edit
+   - Validate JSON syntax and restart the MCP client process.
+
+## Related tests
+
+- `src/cli/commands/__tests__/mcp.test.ts`
+- `src/mcp/__tests__/tool_registry_consistency.test.ts`
+- `src/__tests__/integration_guide_docs.test.ts`
+
+For full client setup matrix and troubleshooting depth, see `docs/mcp-setup.md`.

--- a/docs/integrations/protocol-adapters.md
+++ b/docs/integrations/protocol-adapters.md
@@ -1,0 +1,41 @@
+# Protocol Adapters Reference
+
+This reference describes how integration surfaces map to LiBrainian's canonical interface.
+
+## Canonical interface
+
+- Canonical request/response shape: OpenAPI/REST contract
+- Canonical operation family: query, status, health, feedback
+- Canonical evidence fields: summary, related files, citations, confidence metadata
+
+## Adapter model
+
+| Surface | Adapter role | Notes |
+| --- | --- | --- |
+| CLI | Native command transport | Available now |
+| MCP | Native tool transport | Available now |
+| OpenAPI/REST | Canonical interface | Preview adapter contract |
+| UTCP | Envelope translator to canonical REST | Preview adapter contract |
+| A2A | Task translator to canonical REST | Preview adapter contract |
+| Python SDK | Typed client over canonical REST | Preview adapter contract |
+
+## Compatibility requirements
+
+Every adapter should preserve these invariants:
+
+1. Preserve request intent text without lossy rewriting.
+2. Preserve workspace identity and path boundaries.
+3. Preserve confidence and citation fields from upstream responses.
+4. Surface errors with stable machine-readable codes.
+
+## Building a new adapter
+
+1. Map inbound protocol payloads to the canonical request schema.
+2. Forward to canonical operations (`query`, `status`, `health`, `feedback`).
+3. Map canonical responses back to the protocol without dropping evidence fields.
+4. Add integration tests for translation correctness and error handling.
+
+## Related tests
+
+- `src/__tests__/integration_guide_docs.test.ts`
+- `src/__tests__/capability_contracts.test.ts`

--- a/docs/integrations/python-sdk.md
+++ b/docs/integrations/python-sdk.md
@@ -1,0 +1,61 @@
+# Python SDK Integration
+
+Status: SDK-style bridge (preview).
+
+Until a standalone Python package is published, Python integrations can use a thin typed client over the OpenAPI/REST adapter.
+
+## Prerequisites
+
+- Python 3.10+
+- `pip install requests`
+- A running LiBrainian REST adapter endpoint
+
+## Working example
+
+```python
+from dataclasses import dataclass
+from typing import Any, Dict
+import requests
+
+
+@dataclass
+class LibrarianClient:
+    base_url: str
+    token: str | None = None
+
+    def query(self, intent: str, workspace: str, depth: str = "L2") -> Dict[str, Any]:
+        headers = {"Content-Type": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        response = requests.post(
+            f"{self.base_url}/v1/query",
+            headers=headers,
+            json={"intent": intent, "workspace": workspace, "depth": depth},
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+client = LibrarianClient(base_url="http://localhost:8787")
+result = client.query("Find auth middleware entry points", "/workspace/app")
+print(result.get("summary", "<no summary>"))
+```
+
+## Real-world use case
+
+Use this path when your automation stack is Python-first (CrewAI orchestration, notebooks, or custom ops scripts) but you still want LiBrainian retrieval and citations.
+
+## Troubleshooting
+
+1. `ConnectionError` to adapter host
+   - Confirm adapter host/port and container networking.
+2. HTTP timeout on large repos
+   - Increase request timeout and lower depth/pack count in adapter defaults.
+3. `401 Unauthorized`
+   - Set token headers consistently across notebook/script environments.
+
+## Related tests
+
+- `src/__tests__/integration_guide_docs.test.ts`
+- `src/__tests__/github_readiness_docs.test.ts`

--- a/docs/integrations/rest-api.md
+++ b/docs/integrations/rest-api.md
@@ -1,0 +1,45 @@
+# OpenAPI/REST Integration
+
+Status: adapter contract (preview).
+
+LiBrainian's protocol adapters normalize onto a canonical REST contract so frameworks can integrate through HTTP tooling.
+
+## Prerequisites
+
+- A running LiBrainian REST adapter endpoint
+- `LIBRARIAN_API_BASE` set to the adapter base URL
+- Optional bearer token if your deployment requires auth
+
+## Working example
+
+```bash
+export LIBRARIAN_API_BASE="http://localhost:8787"
+export LIBRARIAN_TOKEN=""
+
+# discover schema
+curl -sS "$LIBRARIAN_API_BASE/openapi.json" | jq '.info.title, .paths | keys'
+
+# query context
+curl -sS -X POST "$LIBRARIAN_API_BASE/v1/query" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $LIBRARIAN_TOKEN" \
+  -d '{"intent":"Trace authentication flow","workspace":"/workspace/app","depth":"L2"}' | jq
+```
+
+## Real-world use case
+
+Use OpenAPI/REST when integrating LiBrainian with agent frameworks that already provide HTTP/OpenAPI tool wrappers (for example, LangChain toolkits or custom gateway layers).
+
+## Troubleshooting
+
+1. `404` on `/openapi.json`
+   - Verify the REST adapter is running and routing docs endpoints.
+2. `401` or `403` responses
+   - Confirm bearer token policy and header wiring.
+3. Schema mismatch in framework auto-tooling
+   - Re-pull `openapi.json` and regenerate typed clients/tool definitions.
+
+## Related tests
+
+- `src/__tests__/integration_guide_docs.test.ts`
+- `src/__tests__/docs_indexer.test.ts`

--- a/docs/integrations/utcp.md
+++ b/docs/integrations/utcp.md
@@ -1,0 +1,54 @@
+# UTCP Integration
+
+Status: adapter contract (preview).
+
+UTCP integration maps UTCP tool envelopes to LiBrainian's canonical query contract.
+
+## Prerequisites
+
+- A UTCP runtime that can dispatch JSON envelopes
+- A translator layer from UTCP payloads to LiBrainian REST requests
+- LiBrainian workspace path available to the adapter
+
+## Working example
+
+```typescript
+// Minimal UTCP -> LiBrainian translator
+
+type UtcpInvoke = {
+  tool: 'librarian.query';
+  input: { intent: string; workspace: string; depth?: 'L0' | 'L1' | 'L2' | 'L3' };
+};
+
+type LibrarianQueryRequest = {
+  intent: string;
+  workspace: string;
+  depth: 'L0' | 'L1' | 'L2' | 'L3';
+};
+
+export function translateUtcpToQuery(req: UtcpInvoke): LibrarianQueryRequest {
+  return {
+    intent: req.input.intent,
+    workspace: req.input.workspace,
+    depth: req.input.depth ?? 'L2',
+  };
+}
+```
+
+## Real-world use case
+
+Use UTCP when your orchestration layer already routes tools through a unified protocol bus and you want LiBrainian available as another tool target.
+
+## Troubleshooting
+
+1. UTCP invocation fails schema validation
+   - Validate envelope keys and enum values before dispatch.
+2. Adapter returns incomplete context
+   - Ensure default depth is set (`L2` is typical for implementation context).
+3. Workspace mismatch errors
+   - Normalize absolute workspace paths in the translator before forwarding.
+
+## Related tests
+
+- `src/__tests__/integration_guide_docs.test.ts`
+- `src/__tests__/capability_contracts.test.ts`

--- a/src/__tests__/integration_guide_docs.test.ts
+++ b/src/__tests__/integration_guide_docs.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+type RequiredGuide = {
+  file: string;
+  title: string;
+};
+
+const repoRoot = process.cwd();
+const integrationsRoot = resolve(repoRoot, 'docs', 'integrations');
+
+const requiredGuides: RequiredGuide[] = [
+  { file: 'mcp.md', title: 'MCP Integration' },
+  { file: 'cli.md', title: 'CLI Integration' },
+  { file: 'rest-api.md', title: 'OpenAPI/REST Integration' },
+  { file: 'utcp.md', title: 'UTCP Integration' },
+  { file: 'a2a.md', title: 'A2A Integration' },
+  { file: 'python-sdk.md', title: 'Python SDK Integration' },
+];
+
+const requiredSections = [
+  'Prerequisites',
+  'Working example',
+  'Real-world use case',
+  'Troubleshooting',
+  'Related tests',
+];
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+describe('integration guide docs', () => {
+  it('ships a universal integration hub with required surface links', () => {
+    const integrationReadme = resolve(integrationsRoot, 'README.md');
+    expect(existsSync(integrationReadme)).toBe(true);
+
+    const content = readFileSync(integrationReadme, 'utf8');
+    expect(content).toContain('# Universal Integration Guide');
+    expect(content).toContain('## Decision Tree');
+
+    for (const guide of requiredGuides) {
+      expect(content).toContain(`./${guide.file}`);
+    }
+
+    expect(existsSync(resolve(integrationsRoot, 'protocol-adapters.md'))).toBe(true);
+  });
+
+  it('keeps all required integration guides with expected sections and code examples', () => {
+    for (const guide of requiredGuides) {
+      const filePath = resolve(integrationsRoot, guide.file);
+      expect(existsSync(filePath)).toBe(true);
+
+      const content = readFileSync(filePath, 'utf8');
+      expect(content).toContain(`# ${guide.title}`);
+
+      for (const section of requiredSections) {
+        const heading = new RegExp(`^##\\s+${escapeRegExp(section)}\\s*$`, 'im');
+        expect(content).toMatch(heading);
+      }
+
+      expect(content).toMatch(/```[a-zA-Z0-9_-]*\n[\s\S]+?```/);
+    }
+  });
+
+  it('links integration docs from root readme and docs index', () => {
+    const readme = readFileSync(resolve(repoRoot, 'README.md'), 'utf8');
+    expect(readme).toContain('## Integration Decision Tree');
+    expect(readme).toContain('docs/integrations/README.md');
+
+    for (const guide of requiredGuides) {
+      expect(readme).toContain(`docs/integrations/${guide.file}`);
+    }
+
+    const docsIndex = readFileSync(resolve(repoRoot, 'docs', 'README.md'), 'utf8');
+    expect(docsIndex).toContain('/docs/integrations/README.md');
+  });
+});


### PR DESCRIPTION
## Summary\n- add a universal integration hub with decision tree for MCP, CLI, OpenAPI/REST, UTCP, A2A, and Python SDK\n- add dedicated integration guides plus a protocol adapter reference\n- add docs validation tests that enforce required guide sections and README/docs index references\n\n## Validation\n- npm test -- --run src/__tests__/integration_guide_docs.test.ts src/__tests__/github_readiness_docs.test.ts src/__tests__/agent_policy_docs.test.ts src/__tests__/real_agent_release_policy_docs.test.ts src/__tests__/conversation_insights_doc.test.ts src/__tests__/agent_session_test_docs.test.ts\n- npm run typecheck\n\nFixes #502