### PR TITLE
fix(embedding): wire purpose vector fallback chain (#664)

### DIFF
--- a/src/__tests__/purpose_vector_fallback.test.ts
+++ b/src/__tests__/purpose_vector_fallback.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @fileoverview Tests for purpose vector fallback chain (Issue #664)
+ *
+ * Verifies that buildPurposeOnlyInput() uses:
+ *   1. llmPurpose when provided
+ *   2. @fileoverview / @description / first JSDoc paragraph from fileContent
+ *   3. Filename-derived name as last resort
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildPurposeOnlyInput } from '../api/embedding_providers/multi_vector_representations.js';
+
+describe('buildPurposeOnlyInput — purpose vector fallback chain', () => {
+  const filePath = 'src/api/sqlite_storage.ts';
+
+  // -------------------------------------------------------------------------
+  // Priority 1: LLM purpose
+  // -------------------------------------------------------------------------
+
+  it('uses llmPurpose when provided', () => {
+    const result = buildPurposeOnlyInput(filePath, 'Stores and retrieves knowledge graph data in SQLite');
+    expect(result).toBe('Stores and retrieves knowledge graph data in SQLite');
+  });
+
+  it('sanitizes control characters in llmPurpose', () => {
+    const result = buildPurposeOnlyInput(filePath, 'Purpose\x00with\x01control\x1fchars');
+    expect(result).toBe('Purposewithcontrolchars');
+  });
+
+  it('prefers llmPurpose over fileContent docstring', () => {
+    const fileContent = `/**
+ * @fileoverview This is the file overview.
+ */
+export class Foo {}
+`;
+    const result = buildPurposeOnlyInput(filePath, 'LLM purpose wins', fileContent);
+    expect(result).toBe('LLM purpose wins');
+  });
+
+  // -------------------------------------------------------------------------
+  // Priority 2: @fileoverview / @description / first JSDoc paragraph
+  // -------------------------------------------------------------------------
+
+  it('uses @fileoverview when llmPurpose is absent', () => {
+    const fileContent = `/**
+ * @fileoverview Manages persistent storage of AST-derived knowledge in SQLite.
+ */
+export class SqliteStorage {}
+`;
+    const result = buildPurposeOnlyInput(filePath, undefined, fileContent);
+    expect(result).toBe('Manages persistent storage of AST-derived knowledge in SQLite.');
+  });
+
+  it('uses @description when @fileoverview is absent', () => {
+    const fileContent = `/**
+ * @description Handles embedding generation and caching.
+ */
+export function generateEmbedding() {}
+`;
+    const result = buildPurposeOnlyInput(filePath, undefined, fileContent);
+    expect(result).toBe('Handles embedding generation and caching.');
+  });
+
+  it('uses first JSDoc paragraph when no @fileoverview or @description', () => {
+    const fileContent = `/**
+ * Provides query routing and scoring logic for multi-vector retrieval.
+ */
+export function scoreQuery() {}
+`;
+    const result = buildPurposeOnlyInput(filePath, undefined, fileContent);
+    expect(result).toContain('Provides query routing and scoring logic');
+  });
+
+  it('skips JSDoc tags in first-paragraph extraction', () => {
+    const fileContent = `/**
+ * @param foo the thing
+ * @returns the other thing
+ */
+export function doSomething() {}
+`;
+    // All lines start with @, so no first-paragraph text — falls back to filename
+    const result = buildPurposeOnlyInput(filePath, undefined, fileContent);
+    // Should not contain the @param content as purpose
+    expect(result).not.toContain('@param');
+  });
+
+  // -------------------------------------------------------------------------
+  // Priority 3: Filename-derived name (last resort)
+  // -------------------------------------------------------------------------
+
+  it('falls back to filename when no llmPurpose and no fileContent', () => {
+    const result = buildPurposeOnlyInput(filePath);
+    expect(result).toBe('Module: sqlite storage');
+  });
+
+  it('falls back to filename when fileContent has no JSDoc', () => {
+    const fileContent = `// plain comment, no JSDoc
+export class Foo {}
+`;
+    const result = buildPurposeOnlyInput(filePath, undefined, fileContent);
+    expect(result).toBe('Module: sqlite storage');
+  });
+
+  it('converts camelCase filename to human-readable words', () => {
+    const result = buildPurposeOnlyInput('src/api/multiVectorRepresentations.ts');
+    expect(result).toBe('Module: multi vector representations');
+  });
+
+  it('converts kebab-case filename to human-readable words', () => {
+    const result = buildPurposeOnlyInput('src/utils/error-handler.ts');
+    expect(result).toBe('Module: error handler');
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge cases
+  // -------------------------------------------------------------------------
+
+  it('throws when filePath is empty', () => {
+    expect(() => buildPurposeOnlyInput('')).toThrow('purpose_input_invalid');
+  });
+
+  it('throws when filePath is whitespace only', () => {
+    expect(() => buildPurposeOnlyInput('   ')).toThrow('purpose_input_invalid');
+  });
+
+  it('handles empty fileContent gracefully', () => {
+    const result = buildPurposeOnlyInput(filePath, undefined, '');
+    expect(result).toBe('Module: sqlite storage');
+  });
+});

--- a/src/agents/ast_indexer.ts
+++ b/src/agents/ast_indexer.ts
@@ -371,8 +371,20 @@ export class AstIndexer {
 
   private generateModulePurpose(filePath: string, functions: FunctionKnowledge[], exports: string[]): string {
     const fileName = path.basename(filePath, path.extname(filePath));
-    const functionNames = functions.map((fn) => fn.name).slice(0, 5);
+
+    // Build composite purpose from function-level purposes (richer than an export list)
+    const functionPurposes = functions
+      .filter((fn) => fn.purpose && fn.purpose.trim())
+      .slice(0, 5)
+      .map((fn) => `${fn.name} (${fn.purpose.trim()})`);
+
+    if (functionPurposes.length > 0) {
+      return `Module that provides: ${functionPurposes.join(', ')}`;
+    }
+
+    // Fallback to export list when no function purposes are available
     if (exports.length > 0) return `Module ${fileName} exporting ${exports.slice(0, 3).join(', ')}${exports.length > 3 ? '...' : ''}`;
+    const functionNames = functions.map((fn) => fn.name).slice(0, 5);
     if (functionNames.length > 0) return `Module ${fileName} containing ${functionNames.join(', ')}${functions.length > 5 ? '...' : ''}`;
     return `Module ${fileName}`;
   }

--- a/src/api/embedding_providers/multi_vector_representations.ts
+++ b/src/api/embedding_providers/multi_vector_representations.ts
@@ -502,8 +502,13 @@ function extractSymbolSummary(content: string): string | null {
  * Build pure purpose input for embedding.
  * This is ONLY the purpose statement - no code, no file paths, no implementation.
  * Designed for "what does X do?" queries.
+ *
+ * Fallback priority:
+ *   1. llmPurpose — highest quality, LLM-extracted
+ *   2. @fileoverview / @description / first JSDoc paragraph from fileContent
+ *   3. Filename-derived human-readable name (last resort)
  */
-function buildPurposeOnlyInput(filePath: string, llmPurpose?: string): string {
+export function buildPurposeOnlyInput(filePath: string, llmPurpose?: string, fileContent?: string): string {
   // Validate filePath to prevent garbage embeddings from empty inputs
   if (!filePath || !filePath.trim()) {
     throw new Error('unverified_by_trace(purpose_input_invalid): filePath is required for purpose embedding');
@@ -518,7 +523,16 @@ function buildPurposeOnlyInput(filePath: string, llmPurpose?: string): string {
     // Use LLM-extracted purpose directly - this is the highest quality signal
     return sanitized;
   }
-  // Fallback: extract from filename and file comment
+
+  // Intermediate fallback: extract @fileoverview / @description / first JSDoc paragraph
+  if (fileContent) {
+    const docComment = extractFileComment(fileContent);
+    if (docComment && docComment.trim()) {
+      return docComment.trim();
+    }
+  }
+
+  // Last resort: derive a human-readable name from the filename
   const basename = filePath.split('/').pop()?.replace(/\.[^.]+$/, '') || '';
   const humanReadable = basename
     .replace(/[-_]/g, ' ')
@@ -549,7 +563,7 @@ export async function generateMultiVector(
 
   // Generate PURPOSE-ONLY vector (no code, pure intent)
   // This is the primary signal for "what does X do?" queries
-  result.purposeInput = buildPurposeOnlyInput(filePath, llmPurpose);
+  result.purposeInput = buildPurposeOnlyInput(filePath, llmPurpose, content);
   const purposeResult = await generateRealEmbedding(result.purposeInput, modelId);
   result.purpose = purposeResult.embedding;
 


### PR DESCRIPTION
## Summary

Fixes the purpose vector quality gap by wiring `extractFileComment()` into `buildPurposeOnlyInput()` fallback chain (Solution A) and replacing the weak export-list heuristic in `generateModulePurpose()` with a composite of function-level purposes (Solution B).

- **Solution A:** When `llmPurpose` is absent, extract `@fileoverview`/`@description`/first JSDoc paragraph via `extractFileComment()` before falling back to filename
- **Solution B:** Compose module purpose from up to 5 function-level purposes instead of raw export lists
- 14 unit tests covering the full fallback priority chain and edge cases

Closes #664

## Agent Run

- **Workflow:** https://github.com/nateschmiedehaus/LiBrainian/actions/runs/22581172612
- **Model:** claude-sonnet-4-6
- **Note:** Agent implemented correctly but git commit was permission-denied due to multiline message matching. Changes recovered via workflow fallback commit.

## Verification

This PR needs independent verification before merge.
The Agent Verify workflow will check it automatically.

<!-- agent_pr = {"issue": 664, "agent": "worker", "run_id": "22581172612"} -->
