### PR TITLE
fix: repair issue 907 query recovery path

### DIFF
--- a/.github/workflows/e2e-cadence.yml
+++ b/.github/workflows/e2e-cadence.yml
@@ -1,6 +1,13 @@
 name: e2e-cadence
 
 on:
+  push:
+    branches:
+      - main
+      - 'codex/**'
+      - 'claude/**'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   # Runs nightly at 6 AM UTC. LLM evaluations are expensive and slow; keeping
   # them off the push path reduces API cost and CI latency. Push CI retains
   # the T0.5 smoke test (closure-policy.yml) for fast reality checks.

--- a/src/__tests__/librarian.test.ts
+++ b/src/__tests__/librarian.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
@@ -184,6 +185,39 @@ describe('Librarian Storage', () => {
     await storage.close();
   });
 
+  it('treats migration 11 as already applied when files_skipped already exists', async () => {
+    const dbPath = path.join(workspace, '.librarian', 'librarian.sqlite');
+    await fs.mkdir(path.dirname(dbPath), { recursive: true });
+
+    const initialStorage = createSqliteStorage(dbPath, workspace);
+    await initialStorage.initialize();
+    await initialStorage.close();
+
+    const db = new Database(dbPath);
+    try {
+      db.prepare('UPDATE librarian_metadata SET value = ? WHERE key = ?').run('10', 'schema_version');
+    } finally {
+      db.close();
+    }
+
+    const reopenedStorage = createSqliteStorage(dbPath, workspace);
+    await reopenedStorage.initialize();
+    await reopenedStorage.close();
+
+    const rootEntries = await fs.readdir(workspace);
+    expect(rootEntries.some((entry) => entry.startsWith('.librarian.backup.v10.'))).toBe(false);
+
+    const migratedDb = new Database(dbPath, { readonly: true });
+    try {
+      const schemaVersion = migratedDb
+        .prepare('SELECT value FROM librarian_metadata WHERE key = ?')
+        .get('schema_version') as { value?: string } | undefined;
+      expect(schemaVersion?.value).toBe('11');
+    } finally {
+      migratedDb.close();
+    }
+  });
+
   it('creates a pre-migration backup of .librarian state', async () => {
     const librarianDir = path.join(workspace, '.librarian');
     const dbPath = path.join(librarianDir, 'librarian.sqlite');
@@ -200,6 +234,25 @@ describe('Librarian Storage', () => {
     const backupFile = path.join(workspace, backupDir ?? '', 'preexisting.txt');
     const backupContent = await fs.readFile(backupFile, 'utf8');
     expect(backupContent.trim()).toBe('seed');
+  });
+
+  it('does not back up workspace .librarian when migrations run against a detached db path', async () => {
+    const librarianDir = path.join(workspace, '.librarian');
+    await fs.mkdir(librarianDir, { recursive: true });
+    await fs.writeFile(path.join(librarianDir, 'preexisting.txt'), 'seed\n', 'utf8');
+
+    const externalDir = await fs.mkdtemp(path.join(os.tmpdir(), 'librarian-detached-db-'));
+    const dbPath = path.join(externalDir, 'librarian.sqlite');
+    const storage = createSqliteStorage(dbPath, workspace);
+    try {
+      await storage.initialize();
+      await storage.close();
+    } finally {
+      await fs.rm(externalDir, { recursive: true, force: true });
+    }
+
+    const rootEntries = await fs.readdir(workspace);
+    expect(rootEntries.some((entry) => entry.startsWith('.librarian.backup.v0.'))).toBe(false);
   });
 
   it('recovers from transient sqlite sidecar ENOENT while creating migration backup', async () => {

--- a/src/agents/__tests__/swarm_runner_checkpoint_consistency.test.ts
+++ b/src/agents/__tests__/swarm_runner_checkpoint_consistency.test.ts
@@ -1,0 +1,76 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { createHash } from 'crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { SwarmRunner } from '../swarm_runner.js';
+import { SqliteLibrarianStorage } from '../../storage/sqlite_storage.js';
+
+async function sha256(filePath: string): Promise<string> {
+  const content = await fs.readFile(filePath);
+  return createHash('sha256').update(content).digest('hex');
+}
+
+describe('SwarmRunner checkpoint consistency', () => {
+  const workspaces: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(workspaces.splice(0).map((workspace) => fs.rm(workspace, { recursive: true, force: true })));
+  });
+
+  it('reindexes files when the checkpoint says up-to-date but storage is missing indexed artifacts', async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'librarian-swarm-checkpoint-'));
+    workspaces.push(workspace);
+
+    const sourceDir = path.join(workspace, 'src');
+    const filePath = path.join(sourceDir, 'query.ts');
+    await fs.mkdir(path.join(workspace, '.librarian', 'swarm'), { recursive: true });
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(filePath, 'export function queryPipeline() { return ["retrieve", "rerank", "synthesize"]; }\n', 'utf8');
+
+    const checkpointPath = path.join(workspace, '.librarian', 'swarm', 'checkpoint.json');
+    const contentHash = await sha256(filePath);
+    await fs.writeFile(checkpointPath, JSON.stringify({
+      schemaVersion: 2,
+      indexerVersion: '2.0.0',
+      configFingerprint: {
+        useAstIndexer: true,
+        generateEmbeddings: false,
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      files: {
+        [filePath]: {
+          contentHash,
+          processedAt: new Date().toISOString(),
+          indexerVersion: '2.0.0',
+        },
+      },
+    }, null, 2), 'utf8');
+
+    const storage = new SqliteLibrarianStorage(path.join(workspace, '.librarian', 'librarian.sqlite'));
+    await storage.initialize();
+
+    try {
+      const result = await new SwarmRunner({
+        storage,
+        workspace,
+        maxWorkers: 2,
+        maxFileSizeBytes: 1024 * 1024,
+        useAstIndexer: true,
+        generateEmbeddings: false,
+        persistGraphMetrics: false,
+      }).run([filePath]);
+
+      expect(result.files).toBe(1);
+      expect(await storage.getFileChecksum(filePath)).toBeTruthy();
+
+      const stats = await storage.getStats();
+      expect(stats.totalModules).toBeGreaterThanOrEqual(1);
+      expect(stats.totalFunctions).toBeGreaterThanOrEqual(1);
+    } finally {
+      await storage.close();
+    }
+  });
+});

--- a/src/agents/swarm_runner.ts
+++ b/src/agents/swarm_runner.ts
@@ -202,7 +202,8 @@ export class SwarmRunner {
     const { pending, contentHashes } = await filterPendingFiles(
       ordered,
       checkpoint,
-      this.forceReindex
+      this.forceReindex,
+      this.storage,
     );
 
     const graphAccumulator = createGraphAccumulator();
@@ -485,7 +486,8 @@ async function computeFileHash(filePath: string): Promise<string> {
 async function filterPendingFiles(
   files: string[],
   checkpoint: CheckpointV2,
-  forceReindex: boolean
+  forceReindex: boolean,
+  storage: LibrarianStorage,
 ): Promise<{ pending: string[]; contentHashes: Map<string, string> }> {
   if (forceReindex) {
     // Compute all hashes upfront for forceReindex
@@ -524,6 +526,19 @@ async function filterPendingFiles(
           return { file, needsProcessing: true, reason: 'content_changed' };
         }
 
+        const storedState = await readStoredFileIndexState(storage, file);
+        if (!storedState.checksum) {
+          return { file, needsProcessing: true, reason: 'storage_missing' };
+        }
+
+        if (storedState.checksum !== currentHash) {
+          return { file, needsProcessing: true, reason: 'storage_stale' };
+        }
+
+        if (storedState.hasArtifacts === false) {
+          return { file, needsProcessing: true, reason: 'artifacts_missing' };
+        }
+
         // File is up-to-date
         return { file, needsProcessing: false, reason: 'unchanged' };
       })
@@ -537,6 +552,40 @@ async function filterPendingFiles(
   }
 
   return { pending, contentHashes };
+}
+
+async function readStoredFileIndexState(
+  storage: LibrarianStorage,
+  filePath: string,
+): Promise<{ checksum: string | null; hasArtifacts: boolean | null }> {
+  let checksum: string | null = null;
+  try {
+    checksum = await storage.getFileChecksum(filePath);
+  } catch {
+    checksum = null;
+  }
+
+  const statsStore = storage as LibrarianStorage & {
+    getFileIndexStats?: (path: string) => Promise<{
+      functions: number;
+      modules: number;
+      embeddings: number;
+      moduleEmbeddings: number;
+      contextPacks: number;
+    }>;
+  };
+
+  if (typeof statsStore.getFileIndexStats !== 'function') {
+    return { checksum, hasArtifacts: null };
+  }
+
+  try {
+    const stats = await statsStore.getFileIndexStats(filePath);
+    const artifactCount = stats.functions + stats.modules + stats.embeddings + stats.moduleEmbeddings + stats.contextPacks;
+    return { checksum, hasArtifacts: artifactCount > 0 };
+  } catch {
+    return { checksum, hasArtifacts: null };
+  }
 }
 
 // Legacy V1 functions (kept for reference, but no longer used)

--- a/src/api/__tests__/architecture_overview.test.ts
+++ b/src/api/__tests__/architecture_overview.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { generateArchitectureOverview } from '../architecture_overview.js';
+import type { LibrarianVersion } from '../../types.js';
+import type { LibrarianStorage } from '../../storage/types.js';
+
+const TEST_VERSION: LibrarianVersion = {
+  major: 1,
+  minor: 0,
+  patch: 0,
+  string: '1.0.0-test',
+  qualityTier: 'full',
+  indexedAt: new Date('2026-03-01T00:00:00.000Z'),
+  indexerVersion: 'test',
+  features: [],
+};
+
+describe('architecture_overview', () => {
+  it('falls back to the filesystem when directory knowledge is missing', async () => {
+    const storage = {
+      getDirectories: async () => [],
+      getGraphEdges: async () => [],
+    } as unknown as LibrarianStorage;
+
+    const pack = await generateArchitectureOverview(storage, process.cwd(), TEST_VERSION);
+
+    expect(pack.summary).toContain('Architecture has');
+    expect(pack.keyFacts.some((fact) => fact.includes('api/'))).toBe(true);
+    expect(pack.relatedFiles.some((file) => file === 'src/api')).toBe(true);
+  });
+});

--- a/src/api/__tests__/bootstrap_watch_staleness.test.ts
+++ b/src/api/__tests__/bootstrap_watch_staleness.test.ts
@@ -176,6 +176,9 @@ describe('isBootstrapRequired watch freshness checks', () => {
 
     try {
       await fs.mkdir(librarianDir, { recursive: true });
+      await fs.writeFile(path.join(librarianDir, 'librarian.sqlite'), '', 'utf8');
+      await fs.writeFile(path.join(librarianDir, 'knowledge.db'), '', 'utf8');
+      await fs.writeFile(path.join(librarianDir, 'evidence_ledger.db'), '', 'utf8');
       await fs.writeFile(
         path.join(librarianDir, 'bootstrap_consistency.json'),
         JSON.stringify({
@@ -249,6 +252,51 @@ describe('isBootstrapRequired watch freshness checks', () => {
       expect(result.required).toBe(true);
       expect(result.reason).toContain('Bootstrap artifacts missing');
       expect(result.reason).toContain('knowledge.db');
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('requires bootstrap when consistency snapshot shows an effectively empty librarian.sqlite', async () => {
+    const { isBootstrapRequired } = await import('../bootstrap.js');
+    const { getWatchState } = await import('../../state/watch_state.js');
+    const { getCurrentGitSha } = await import('../../utils/git.js');
+
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'librarian-consistency-skew-'));
+    const librarianDir = path.join(workspace, '.librarian');
+    const nowIso = new Date().toISOString();
+
+    try {
+      await fs.mkdir(librarianDir, { recursive: true });
+      await fs.writeFile(path.join(librarianDir, 'librarian.sqlite'), '', 'utf8');
+      await fs.writeFile(path.join(librarianDir, 'knowledge.db'), '', 'utf8');
+      await fs.writeFile(path.join(librarianDir, 'evidence_ledger.db'), '', 'utf8');
+      await fs.writeFile(
+        path.join(librarianDir, 'bootstrap_consistency.json'),
+        JSON.stringify({
+          kind: 'BootstrapConsistencyState.v1',
+          schema_version: 1,
+          workspace,
+          generation_id: 'gen-test',
+          status: 'complete',
+          started_at: nowIso,
+          updated_at: nowIso,
+          completed_at: nowIso,
+          artifacts: {
+            librarian: { path: path.join(librarianDir, 'librarian.sqlite'), exists: true, size_bytes: 4096 },
+            knowledge: { path: path.join(librarianDir, 'knowledge.db'), exists: true, size_bytes: 64000 },
+            evidence: { path: path.join(librarianDir, 'evidence_ledger.db'), exists: true, size_bytes: 64000 },
+          },
+        }),
+        'utf8',
+      );
+
+      vi.mocked(getWatchState).mockResolvedValue(null as never);
+      vi.mocked(getCurrentGitSha).mockReturnValue(undefined);
+
+      const result = await isBootstrapRequired(workspace, createStorageStub());
+      expect(result.required).toBe(true);
+      expect(result.reason).toContain('effectively empty');
     } finally {
       await fs.rm(workspace, { recursive: true, force: true });
     }

--- a/src/api/__tests__/query_cache_store_utils.test.ts
+++ b/src/api/__tests__/query_cache_store_utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { ContextPack, LibrarianQuery, LibrarianVersion, QueryCacheEntry } from '../../types.js';
 import {
   getQueryCache,
+  isCacheableQueryResponse,
   setCachedQuery,
   type QueryCacheStore,
 } from '../query_cache_store_utils.js';
@@ -121,5 +122,45 @@ describe('query_cache_store_utils', () => {
       maxEntries: 1000,
       maxAgeMs: 30 * 60 * 1000,
     });
+  });
+
+  it('does not persist low-confidence or insufficient responses', async () => {
+    const response = {
+      ...makeResponse('L3'),
+      totalConfidence: 0.1,
+      retrievalStatus: 'insufficient' as const,
+      retrievalInsufficient: true,
+    };
+    const upsertQueryCacheEntry = vi.fn(async (_entry: QueryCacheEntry) => undefined);
+    const storage = { upsertQueryCacheEntry } as QueryCacheStore;
+
+    expect(isCacheableQueryResponse(response)).toBe(false);
+    await setCachedQuery('key-skip', response, storage, makeQuery('L3'));
+
+    expect(upsertQueryCacheEntry).not.toHaveBeenCalled();
+  });
+
+  it('ignores persisted low-confidence cache entries during hydration', async () => {
+    const response = {
+      ...makeResponse('L3'),
+      totalConfidence: 0.2,
+      retrievalStatus: 'insufficient' as const,
+      retrievalInsufficient: true,
+    };
+    const entry: QueryCacheEntry = {
+      queryHash: 'key-bad',
+      queryParams: JSON.stringify(response.query),
+      response: serializeCachedResponse(response),
+      createdAt: new Date().toISOString(),
+      lastAccessed: new Date().toISOString(),
+      accessCount: 1,
+    };
+    const getQueryCacheEntry = vi.fn(async (_key: string) => entry);
+    const storage = { getQueryCacheEntry } as QueryCacheStore;
+
+    const cache = getQueryCache(storage);
+    const hydrated = await cache.get('key-bad');
+
+    expect(hydrated).toBeNull();
   });
 });

--- a/src/api/__tests__/query_filename_injection.test.ts
+++ b/src/api/__tests__/query_filename_injection.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { __testing } from '../query.js';
+import type { LibrarianStorage } from '../../storage/types.js';
+import type { LibrarianVersion } from '../../types.js';
+
+const TEST_VERSION: LibrarianVersion = {
+  major: 1,
+  minor: 0,
+  patch: 0,
+  string: '1.0.0-test',
+  qualityTier: 'full',
+  indexedAt: new Date('2026-03-01T00:00:00.000Z'),
+  indexerVersion: 'test',
+  features: [],
+};
+
+describe('query filename candidate injection', () => {
+  it('injects module candidates for strong multi-word filename matches', async () => {
+    const storage = {
+      getFiles: async () => ([
+        { path: 'src/api/query.ts' },
+        { path: 'src/query/scoring.ts' },
+        { path: 'src/constructions/processes/hallucinated_api_detector.ts' },
+      ]),
+      getModuleByPath: async (filePath: string) => ({
+        id: `mod:${filePath}`,
+        path: filePath,
+        purpose: `Module ${filePath}`,
+        exports: [],
+        dependencies: [],
+        confidence: 0.8,
+      }),
+      getFunctionsByPath: async () => [],
+    } as unknown as LibrarianStorage;
+
+    const result = await __testing.injectFilenameCandidates(
+      'Where is the query pipeline implemented and what are its stages?',
+      [],
+      storage,
+    );
+
+    expect(result.added).toBeGreaterThan(0);
+    expect(result.candidates.some((candidate) =>
+      candidate.entityType === 'module' && candidate.path === 'src/api/query.ts'
+    )).toBe(true);
+  });
+
+  it('materializes a JIT module pack when a module candidate has no prebuilt pack', async () => {
+    const storage = {
+      getContextPackForTarget: async () => null,
+      getContextPacks: async () => [],
+      getModule: async (id: string) => ({
+        id,
+        path: 'src/api/query.ts',
+        purpose: 'Main query pipeline that orchestrates retrieval stages',
+        exports: ['queryLibrarian', 'getQueryPipelineDefinition'],
+        dependencies: ['src/query/scoring.ts'],
+        confidence: 0.8,
+      }),
+      getFunctionsByPath: async () => ([
+        {
+          id: 'fn:queryLibrarian',
+          name: 'queryLibrarian',
+          startLine: 1,
+          endLine: 200,
+        },
+      ]),
+      getMetadata: async () => ({ workspace: process.cwd() }),
+      getVersion: async () => TEST_VERSION,
+    } as unknown as LibrarianStorage;
+
+    const packs = await __testing.collectCandidatePacks(storage, [{
+      entityId: 'mod:src/api/query.ts',
+      entityType: 'module',
+      path: 'src/api/query.ts',
+      semanticSimilarity: 0.5,
+      confidence: 0.8,
+      recency: 0.5,
+      pagerank: 0,
+      centrality: 0,
+      communityId: null,
+    }], 'L3');
+
+    expect(packs).toHaveLength(1);
+    expect(packs[0]?.packType).toBe('module_context');
+    expect(packs[0]?.relatedFiles).toContain('src/api/query.ts');
+    expect(packs[0]?.codeSnippets.length).toBeGreaterThan(0);
+  });
+});

--- a/src/api/__tests__/query_filesystem_fallback.test.ts
+++ b/src/api/__tests__/query_filesystem_fallback.test.ts
@@ -1,0 +1,114 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { queryLibrarian } from '../query.js';
+import { createSqliteStorage } from '../../storage/sqlite_storage.js';
+import { getCurrentVersion } from '../../index.js';
+
+describe('query filesystem fallback', () => {
+  const workspaces: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(workspaces.splice(0).map((workspace) => fs.rm(workspace, { recursive: true, force: true })));
+  });
+
+  it('returns source-backed packs when indexed context packs are unavailable', async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'librarian-query-fallback-'));
+    workspaces.push(workspace);
+
+    const sourceDir = path.join(workspace, 'src', 'api');
+    const sourceFile = path.join(sourceDir, 'query.ts');
+    await fs.mkdir(path.join(workspace, '.librarian'), { recursive: true });
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(sourceFile, [
+      'export const QUERY_PIPELINE_STAGES = [\'adequacy_scan\', \'semantic_retrieval\', \'reranking\', \'synthesis\'];',
+      'export function queryPipeline() {',
+      '  return QUERY_PIPELINE_STAGES;',
+      '}',
+      '',
+    ].join('\n'), 'utf8');
+
+    const storage = createSqliteStorage(path.join(workspace, '.librarian', 'librarian.sqlite'), workspace);
+    await storage.initialize();
+    await storage.setMetadata({
+      version: getCurrentVersion(),
+      workspace,
+      lastBootstrap: new Date(),
+      lastIndexing: new Date(),
+      totalFiles: 1,
+      totalFunctions: 0,
+      totalContextPacks: 0,
+      qualityTier: 'mvp',
+    });
+
+    try {
+      const response = await queryLibrarian({
+        intent: 'Where is the query pipeline implemented and what are its stages?',
+        depth: 'L0',
+        llmRequirement: 'disabled',
+      }, storage);
+
+      expect(response.packs.length).toBeGreaterThan(0);
+      expect(response.retrievalStatus).not.toBe('insufficient');
+      expect(response.packs[0]?.relatedFiles).toContain('src/api/query.ts');
+      expect(response.packs[0]?.keyFacts.join(' ')).toContain('Matched terms');
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it('deprioritizes dead-code trap paths when a live exported match exists', async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'librarian-query-fallback-dead-code-'));
+    workspaces.push(workspace);
+
+    await fs.mkdir(path.join(workspace, '.librarian'), { recursive: true });
+    await fs.mkdir(path.join(workspace, 'src', 'live'), { recursive: true });
+    await fs.mkdir(path.join(workspace, 'src', 'dead'), { recursive: true });
+    await fs.writeFile(path.join(workspace, 'src', 'live', 'billingPolicy.ts'), [
+      'export interface Invoice { id: string; daysOverdue: number; }',
+      'export function enforceActiveBillingPolicy(invoice: Invoice) {',
+      '  return invoice.daysOverdue >= 30 ? \"pay-now\" : \"allow-grace-period\";',
+      '}',
+      'export const ACTIVE_BILLING_POLICY = \"active-billing-policy-enforcement\";',
+      '',
+    ].join('\n'), 'utf8');
+    await fs.writeFile(path.join(workspace, 'src', 'dead', 'legacyBilling.ts'), [
+      '/*',
+      'LEGACY BILLING ENGINE (DEAD CODE)',
+      'This block intentionally contains misleading terms like billing policy,',
+      'overdue invoice processing, and payment enforcement.',
+      '*/',
+      'export const LEGACY_BILLING_DEAD_CODE = true;',
+      '',
+    ].join('\n'), 'utf8');
+
+    const storage = createSqliteStorage(path.join(workspace, '.librarian', 'librarian.sqlite'), workspace);
+    await storage.initialize();
+    await storage.setMetadata({
+      version: getCurrentVersion(),
+      workspace,
+      lastBootstrap: new Date(),
+      lastIndexing: new Date(),
+      totalFiles: 2,
+      totalFunctions: 0,
+      totalContextPacks: 0,
+      qualityTier: 'mvp',
+    });
+
+    try {
+      const response = await queryLibrarian({
+        intent: 'Locate ACTIVE_BILLING_POLICY enforcement for overdue invoice handling.',
+        depth: 'L0',
+        llmRequirement: 'disabled',
+      }, storage);
+
+      expect(response.packs.length).toBeGreaterThan(0);
+      expect(response.packs[0]?.relatedFiles).toContain('src/live/billingPolicy.ts');
+      expect(response.packs[0]?.relatedFiles).not.toContain('src/dead/legacyBilling.ts');
+    } finally {
+      await storage.close();
+    }
+  });
+});

--- a/src/api/__tests__/query_intent_classification.test.ts
+++ b/src/api/__tests__/query_intent_classification.test.ts
@@ -82,6 +82,14 @@ describe('classifyQueryIntent', () => {
       expect(result.isCodeQuery).toBe(true);
       expect(result.isMetaQuery).toBe(false);
     });
+
+    it('classifies mixed location + structure questions as implementation-first queries', () => {
+      const result = classifyQueryIntent('Where is the query pipeline implemented and what are its stages?');
+      expect(result.isCodeQuery).toBe(true);
+      expect(result.isMetaQuery).toBe(false);
+      expect(result.isFeatureLocationQuery).toBe(true);
+      expect(result.featureTarget).toBe('query pipeline');
+    });
   });
 
   describe('hybrid query detection', () => {

--- a/src/api/__tests__/query_intent_patterns.test.ts
+++ b/src/api/__tests__/query_intent_patterns.test.ts
@@ -67,6 +67,7 @@ describe('query_intent_patterns', () => {
     expect(hasMatch(CODE_QUALITY_PATTERNS, 'code quality report')).toBe(true);
     expect(hasMatch(CODE_REVIEW_QUERY_PATTERNS, 'review this file before merge')).toBe(true);
     expect(hasMatch(FEATURE_LOCATION_PATTERNS, 'where is authentication implemented')).toBe(true);
+    expect(hasMatch(FEATURE_LOCATION_PATTERNS, 'where is the query pipeline implemented')).toBe(true);
     expect(hasMatch(REFACTORING_OPPORTUNITIES_PATTERNS, 'what should I refactor')).toBe(true);
   });
 

--- a/src/api/__tests__/query_intent_targets.test.ts
+++ b/src/api/__tests__/query_intent_targets.test.ts
@@ -30,6 +30,7 @@ describe('query intent target extractors', () => {
   it('extracts feature targets', () => {
     expect(extractFeatureTarget('where is authentication implemented')).toBe('authentication');
     expect(extractFeatureTarget('find the login feature')).toBe('login');
+    expect(extractFeatureTarget('where is the query pipeline implemented')).toBe('query pipeline');
     expect(extractFeatureTarget('show me architecture overview')).toBeUndefined();
   });
 

--- a/src/api/__tests__/query_pipeline.test.ts
+++ b/src/api/__tests__/query_pipeline.test.ts
@@ -610,6 +610,43 @@ describe('query pipeline definition', () => {
     expect(synthesizeQueryAnswerFn).not.toHaveBeenCalled();
   });
 
+  it('prefers quick synthesis when retrieval is degraded even for non-summary intents', async () => {
+    const stageTracker = __testing.createStageTracker();
+    const recordCoverageGap = (stage: StageName, message: string, severity?: StageIssueSeverity) => {
+      stageTracker.issue(stage, { message, severity: severity ?? 'minor' });
+    };
+    const createQuickAnswerFn = vi.fn().mockReturnValue({
+      answer: 'degraded-quick',
+      confidence: 0.65,
+      citations: ['pack-1'],
+      keyInsights: ['insight'],
+      uncertainties: [],
+    });
+    const synthesizeQueryAnswerFn = vi.fn();
+
+    const explanationParts: string[] = [];
+    const result = await __testing.runSynthesisStage({
+      query: { intent: 'How are errors handled across the codebase?', depth: 'L1' },
+      storage: {} as LibrarianStorage,
+      finalPacks: [createPack({})],
+      stageTracker,
+      recordCoverageGap,
+      explanationParts,
+      synthesisEnabled: true,
+      preferQuickSynthesis: true,
+      workspaceRoot: process.cwd(),
+      canAnswerFromSummariesFn: () => false,
+      createQuickAnswerFn,
+      synthesizeQueryAnswerFn,
+    });
+
+    expect(result.synthesis?.answer).toBe('degraded-quick');
+    expect(result.synthesisMode).toBe('heuristic');
+    expect(createQuickAnswerFn).toHaveBeenCalledTimes(1);
+    expect(synthesizeQueryAnswerFn).not.toHaveBeenCalled();
+    expect(explanationParts.join(' ')).toContain('degraded retrieval state');
+  });
+
   it('uses full synthesis when summaries are insufficient', async () => {
     const stageTracker = __testing.createStageTracker();
     const recordCoverageGap = (stage: StageName, message: string, severity?: StageIssueSeverity) => {

--- a/src/api/__tests__/query_semantic_cache_utils.test.ts
+++ b/src/api/__tests__/query_semantic_cache_utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { LibrarianQuery, LibrarianVersion, LlmRequirement } from '../../types.js';
 import {
   buildQueryCacheKey,
+  buildQueryCacheVersionPrefix,
   buildSemanticCacheScopeSignature,
   classifySemanticCacheCategory,
   computeSemanticIntentSimilarity,
@@ -51,6 +52,10 @@ describe('query_semantic_cache_utils', () => {
     const keyA = buildQueryCacheKey(queryA, VERSION, LLM_REQUIREMENT, true);
     const keyB = buildQueryCacheKey(queryB, VERSION, LLM_REQUIREMENT, true);
     expect(keyA).toBe(keyB);
+  });
+
+  it('includes the cache schema version in the reusable prefix', () => {
+    expect(buildQueryCacheVersionPrefix(VERSION)).toMatch(/^qv4:route2:synth2:2\.0\.0:/);
   });
 
   it('classifies diagnostic, conceptual, and lookup intents', () => {

--- a/src/api/__tests__/query_synthesis.test.ts
+++ b/src/api/__tests__/query_synthesis.test.ts
@@ -164,21 +164,144 @@ describe('quick synthesis heuristics', () => {
     expect(result).toBe(true);
   });
 
+  it('allows summary-only answers for broad codebase queries when packs are confident', () => {
+    const result = canAnswerFromSummaries(
+      { intent: 'How are errors handled across the codebase?', depth: 'L1' },
+      [samplePack]
+    );
+    expect(result).toBe(true);
+  });
+
+  it('allows summary-only answers for broad codebase queries with distributed moderate-confidence packs', () => {
+    const result = canAnswerFromSummaries(
+      { intent: 'How are errors handled across the codebase?', depth: 'L1' },
+      [
+        {
+          ...samplePack,
+          packId: 'pack-a',
+          relatedFiles: ['src/cli/errors.ts'],
+          confidence: 0.34,
+          summary: 'CLI commands normalize operational failures into structured user-facing errors.',
+          keyFacts: ['CLI errors are rendered through a structured envelope.'],
+        },
+        {
+          ...samplePack,
+          packId: 'pack-b',
+          relatedFiles: ['src/core/errors.ts'],
+          confidence: 0.31,
+          summary: 'Core services define the shared typed error hierarchy used across modules.',
+          keyFacts: ['Core errors define typed domain failures.'],
+        },
+      ]
+    );
+
+    expect(result).toBe(true);
+  });
+
   it('emits a location-focused quick answer for where-is intents', () => {
     const answer = createQuickAnswer(
       { intent: 'Where is query synthesis executed?', depth: 'L1' },
       [
+        {
+          ...samplePack,
+          packId: 'pack-distractor',
+          targetId: 'src/api/query_cache_response_utils.ts',
+          relatedFiles: ['src/api/query_cache_response_utils.ts'],
+          summary: 'Cache response helpers for query output serialization.',
+          confidence: 0.97,
+        },
         samplePack,
         {
           ...samplePack,
           packId: 'pack-2',
+          targetId: 'src/api/query.ts',
           relatedFiles: ['src/api/query.ts'],
-          confidence: 0.79,
+          confidence: 0.95,
+          summary: 'Query synthesis execution and stage orchestration live in query.ts.',
+          keyFacts: ['query.ts runs the synthesis stage for query responses.'],
         },
       ]
     );
     expect(answer.answer.toLowerCase()).toContain('query synthesis executed');
     expect(answer.answer).toContain('src/api/query.ts');
     expect(answer.synthesized).toBe(true);
+  });
+
+  it('prefers snippet and target source files over transitive related files in location answers', () => {
+    const answer = createQuickAnswer(
+      { intent: 'Where is the query pipeline implemented?', depth: 'L1' },
+      [
+        {
+          ...samplePack,
+          targetId: '/tmp/workspace/src/api/query.ts',
+          relatedFiles: [
+            'src/storage/types.js',
+            'src/types.js',
+          ],
+          codeSnippets: [
+            {
+              filePath: '/tmp/workspace/src/api/query.ts',
+              startLine: 1,
+              endLine: 5,
+              content: 'export function queryLibrarian() {}',
+              language: 'typescript',
+            },
+          ],
+        },
+      ]
+    );
+
+    expect(answer.answer).toContain('src/api/query.ts');
+    expect(answer.answer).not.toContain('src/storage/types.js');
+  });
+
+  it('emits a multi-file summary for generic quick answers', () => {
+    const answer = createQuickAnswer(
+      { intent: 'How are errors handled across the codebase?', depth: 'L1' },
+      [
+        {
+          ...samplePack,
+          relatedFiles: ['src/cli/errors.ts'],
+          keyFacts: ['Structured error envelope for agents'],
+        },
+        {
+          ...samplePack,
+          packId: 'pack-2',
+          relatedFiles: ['src/core/errors.ts'],
+          keyFacts: ['Typed error hierarchy'],
+          confidence: 0.79,
+        },
+      ]
+    );
+
+    expect(answer.answer).toContain('src/cli/errors.ts');
+    expect(answer.answer).toContain('Structured error envelope for agents');
+    expect(answer.synthesized).toBe(true);
+  });
+
+  it('emits a distributed cross-cutting summary for broad codebase queries', () => {
+    const answer = createQuickAnswer(
+      { intent: 'How are errors handled across the codebase?', depth: 'L1' },
+      [
+        {
+          ...samplePack,
+          packId: 'pack-a',
+          relatedFiles: ['src/cli/errors.ts'],
+          confidence: 0.34,
+          keyFacts: ['CLI errors are rendered through a structured envelope.'],
+        },
+        {
+          ...samplePack,
+          packId: 'pack-b',
+          relatedFiles: ['src/core/errors.ts'],
+          confidence: 0.31,
+          keyFacts: ['Core errors define typed domain failures.'],
+        },
+      ]
+    );
+
+    expect(answer.answer).toContain('errors are handled across');
+    expect(answer.answer).toContain('src/cli/errors.ts');
+    expect(answer.answer).toContain('CLI errors are rendered through a structured envelope.');
   });
 });

--- a/src/api/__tests__/retrieval_escalation.test.ts
+++ b/src/api/__tests__/retrieval_escalation.test.ts
@@ -175,4 +175,38 @@ describe('retrieval escalation policy', () => {
     expect(questions).toHaveLength(3);
     expect(expanded).toContain('session');
   });
+
+  it('does not inject absolute workspace path tokens when expanding escalation intent', () => {
+    const intent = 'Where is the query pipeline implemented and what are its stages?';
+    const expanded = expandEscalationIntent(intent, [
+      pack({
+        targetId: '/Volumes/BigSSD4/nathanielschmiedehaus/Documents/software/librarian/src/constructions/processes/hallucinated_api_detector.ts:detectHallucinatedApiUsage',
+        relatedFiles: [
+          '/Volumes/BigSSD4/nathanielschmiedehaus/Documents/software/librarian/src/constructions/processes/hallucinated_api_detector.ts',
+        ],
+        summary: 'Detects hallucinated API usage in generated changes',
+        keyFacts: ['Used in construction verification flows'],
+      }),
+    ]);
+
+    expect(expanded).toBe(intent);
+    expect(expanded).not.toContain('volumes');
+    expect(expanded).not.toContain('bigssd4');
+    expect(expanded).not.toContain('documents');
+    expect(expanded).not.toContain('software');
+    expect(expanded).not.toContain('librarian');
+  });
+
+  it('keeps architecture and location queries stable during escalation', () => {
+    const intent = 'Where is the query pipeline implemented and what are its stages?';
+    const expanded = expandEscalationIntent(intent, [
+      pack({
+        targetId: 'src/constructions/processes/hallucinated_api_detector.ts:detectHallucinatedApiUsage',
+        summary: 'Module hallucinated_api_detector exporting createHallucinatedApiDetectorConstruction',
+        keyFacts: ['Top-level routines: normalizePathSeparators, parseSemver'],
+      }),
+    ]);
+
+    expect(expanded).toBe(intent);
+  });
 });

--- a/src/api/architecture_overview.ts
+++ b/src/api/architecture_overview.ts
@@ -6,6 +6,9 @@
  * and module dependencies when explicit architecture documentation is not available.
  */
 
+import { promises as fs } from 'node:fs';
+import type { Dirent } from 'node:fs';
+import path from 'node:path';
 import type { ContextPack, LibrarianVersion, ContextPackType, DirectoryKnowledge, GraphEdge } from '../types.js';
 import type { LibrarianStorage } from '../storage/types.js';
 
@@ -129,6 +132,9 @@ export async function inferArchitectureLayers(
 ): Promise<ArchitectureLayer[]> {
   // Get top-level directories (depth 1 = direct children of src/)
   const directories = await storage.getDirectories({ maxDepth: 2, minDepth: 1 });
+  if (directories.length === 0) {
+    return discoverArchitectureLayersFromFilesystem(storage, workspaceRoot);
+  }
 
   // Get import edges to understand dependencies
   const importEdges = await storage.getGraphEdges({ edgeTypes: ['imports'] });
@@ -175,6 +181,9 @@ export async function inferArchitectureLayers(
       layers.set(dir.name, layer);
     }
   }
+  if (layers.size === 0) {
+    return discoverArchitectureLayersFromFilesystem(storage, workspaceRoot);
+  }
 
   // Infer dependencies from import edges
   const layerDependencies = inferLayerDependencies(importEdges, layers);
@@ -197,6 +206,75 @@ export async function inferArchitectureLayers(
     'analysis': 5,
     'utility': 6,
     'other': 7,
+  };
+
+  return Array.from(layers.values()).sort((a, b) => typeOrder[a.type] - typeOrder[b.type]);
+}
+
+async function discoverArchitectureLayersFromFilesystem(
+  storage: LibrarianStorage,
+  workspaceRoot: string
+): Promise<ArchitectureLayer[]> {
+  const srcRoot = path.join(workspaceRoot, 'src');
+  let entries: Dirent[] = [];
+  try {
+    entries = await fs.readdir(srcRoot, { withFileTypes: true, encoding: 'utf8' });
+  } catch {
+    return [];
+  }
+
+  const ignored = new Set(['__tests__', 'test', 'tests', 'node_modules', 'dist', 'build', 'coverage']);
+  const layers = new Map<string, ArchitectureLayer>();
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || ignored.has(entry.name)) {
+      continue;
+    }
+
+    const dirName = entry.name.toLowerCase();
+    const relativePath = path.posix.join('src', entry.name);
+    const absolutePath = path.join(srcRoot, entry.name);
+    const mapping = LAYER_TYPE_MAPPINGS[dirName];
+    let moduleFiles: string[] = [];
+
+    try {
+      const childEntries = await fs.readdir(absolutePath, { withFileTypes: true, encoding: 'utf8' });
+      moduleFiles = childEntries
+        .filter((child) => child.isFile() && /\.(?:ts|tsx|js|jsx|mjs|cjs)$/.test(child.name))
+        .map((child) => path.posix.join(relativePath, child.name))
+        .slice(0, 5);
+    } catch {
+      moduleFiles = [];
+    }
+
+    layers.set(entry.name, {
+      name: entry.name,
+      type: mapping?.type ?? 'other',
+      directories: [relativePath],
+      modules: moduleFiles,
+      purpose: mapping?.purpose ?? `${entry.name} module`,
+      dependsOn: [],
+    });
+  }
+
+  const importEdges = await storage.getGraphEdges({ edgeTypes: ['imports'] }).catch(() => []);
+  const layerDependencies = inferLayerDependencies(importEdges, layers);
+  for (const [layerName, deps] of Array.from(layerDependencies.entries())) {
+    const layer = layers.get(layerName);
+    if (layer) {
+      layer.dependsOn = deps;
+    }
+  }
+
+  const typeOrder: Record<ArchitectureLayer['type'], number> = {
+    interface: 0,
+    application: 1,
+    domain: 2,
+    data: 3,
+    infrastructure: 4,
+    analysis: 5,
+    utility: 6,
+    other: 7,
   };
 
   return Array.from(layers.values()).sort((a, b) => typeOrder[a.type] - typeOrder[b.type]);

--- a/src/api/bootstrap.ts
+++ b/src/api/bootstrap.ts
@@ -362,6 +362,13 @@ async function collectBootstrapArtifacts(workspace: string): Promise<BootstrapCo
   return { librarian, knowledge, evidence };
 }
 
+function hasSuspiciousArtifactSkew(artifacts: BootstrapConsistencyState['artifacts']): boolean {
+  const librarianSize = artifacts.librarian.size_bytes ?? 0;
+  const knowledgeSize = artifacts.knowledge.size_bytes ?? 0;
+  const evidenceSize = artifacts.evidence.size_bytes ?? 0;
+  return librarianSize <= 4096 && (knowledgeSize > 4096 || evidenceSize > 4096);
+}
+
 function resolveBootstrapBackupMaxBytes(): number {
   const raw =
     process.env.LIBRARIAN_BOOTSTRAP_BACKUP_MAX_BYTES
@@ -2088,6 +2095,12 @@ export async function isBootstrapRequired(
         reason: `Bootstrap artifacts missing (${missingArtifacts.join(', ')}); run \`librarian bootstrap --force\` to restore consistent state.`,
       };
     }
+    if (hasSuspiciousArtifactSkew(consistency.artifacts)) {
+      return {
+        required: true,
+        reason: 'Bootstrap artifact snapshot is inconsistent (librarian.sqlite is effectively empty while auxiliary stores contain data); run `librarian bootstrap --force` to restore consistent state.',
+      };
+    }
   }
   const existingVersion = await detectLibrarianVersion(storage);
   const targetQualityTier = options?.targetQualityTier ?? 'full';
@@ -2737,12 +2750,14 @@ export async function bootstrapProject(
     const totalDurationMs = report.completedAt!.getTime() - report.startedAt.getTime();
     void globalEventBus.emit(createBootstrapCompleteEvent(workspace, true, totalDurationMs));
     if (report.completedAt) {
+      const semanticPhase = report.phases.find((phase) => phase.phase.name === 'semantic_indexing');
+      const indexedFileTotal = semanticPhase?.metrics?.totalFiles ?? report.totalFilesProcessed;
       await writeIndexState(
         {
           phase: 'ready',
           lastFullIndex: report.completedAt.toISOString(),
-          progress: report.totalFilesProcessed > 0
-            ? { total: report.totalFilesProcessed, completed: report.totalFilesProcessed }
+          progress: indexedFileTotal > 0
+            ? { total: indexedFileTotal, completed: indexedFileTotal }
             : undefined,
         },
         { force: true }
@@ -2857,16 +2872,17 @@ export async function bootstrapProject(
       // Keep original error as the primary failure signal.
     }
     try {
+      const restoredArtifacts = await collectBootstrapArtifacts(workspace);
       await writeBootstrapConsistencyState(workspace, {
         kind: 'BootstrapConsistencyState.v1',
         schema_version: 1,
         workspace,
         generation_id: consistencyGenerationId,
-        status: restoredFromBackup ? 'complete' : 'failed',
+        status: 'failed',
         started_at: recoveryStartedAt,
         updated_at: new Date().toISOString(),
         completed_at: report.completedAt.toISOString(),
-        artifacts: await collectBootstrapArtifacts(workspace),
+        artifacts: restoredArtifacts,
         last_error: restoredFromBackup
           ? `bootstrap_failed_restored_previous_state: ${report.error}`
           : report.error,
@@ -2902,13 +2918,18 @@ async function upsertMetadataForSuccessfulBootstrap(
       storage.getStats(),
       storage.getFiles({}),
     ]);
+    const semanticPhase = report.phases.find((phase) => phase.phase.name === 'semantic_indexing');
+    const indexedFileTotal = semanticPhase?.metrics?.totalFiles
+      ?? report.totalFilesProcessed
+      ?? existingMetadata?.totalFiles
+      ?? files.length;
 
 	const nextMetadata: LibrarianMetadata = {
 	  version: report.version,
 	  workspace,
 	  lastBootstrap: completedAt,
 	  lastIndexing: completedAt,
-	  totalFiles: existingMetadata?.totalFiles ?? files.length,
+	  totalFiles: indexedFileTotal,
 	  totalFunctions: stats.totalFunctions,
 	  totalContextPacks: stats.totalContextPacks,
 	  qualityTier: report.version.qualityTier,

--- a/src/api/migrations.ts
+++ b/src/api/migrations.ts
@@ -21,6 +21,11 @@ export interface LibrarianSchemaMigrationReportV1 {
   applied: AppliedMigration[];
 }
 
+export interface ApplyMigrationsOptions {
+  workspaceRoot?: string;
+  dbPath?: string;
+}
+
 const INLINE_MIGRATIONS: Record<string, string> = {
   '002_ingestion': [
     'CREATE TABLE IF NOT EXISTS librarian_ingested_items (id TEXT PRIMARY KEY, source_type TEXT NOT NULL, source_version TEXT NOT NULL, ingested_at TEXT NOT NULL, payload TEXT NOT NULL, metadata TEXT NOT NULL DEFAULT \"{}\");',
@@ -94,6 +99,10 @@ const MAX_MIGRATION_BACKUPS = 1;
 const resolveBackupDir = (workspaceRoot: string, fromVersion: number): string =>
   path.join(workspaceRoot, `${BACKUP_DIR_PREFIX}${fromVersion}.${Date.now()}.${randomUUID()}`);
 const hasMetadataTable = (db: Database.Database): boolean => Boolean(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='librarian_metadata'").get());
+const hasColumn = (db: Database.Database, tableName: string, columnName: string): boolean => {
+  const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name?: string }>;
+  return rows.some((row) => row.name === columnName);
+};
 const hashSql = (sql: string): string => createHash('sha256').update(sql).digest('hex');
 type CopyDirectoryFn = typeof fs.cp;
 const defaultCopyDirectory: CopyDirectoryFn = (src, dest, options) => fs.cp(src, dest, options);
@@ -101,6 +110,10 @@ let backupCopyDirectory: CopyDirectoryFn = defaultCopyDirectory;
 
 export function __setMigrationBackupCopyForTests(copyFn: CopyDirectoryFn | null): void {
   backupCopyDirectory = copyFn ?? defaultCopyDirectory;
+}
+
+function isMigrationPreapplied(db: Database.Database, migration: MigrationDefinition): boolean {
+  return migration.version === 11 && hasColumn(db, 'librarian_indexing_history', 'files_skipped');
 }
 
 const loadMigrationSql = async (file: string): Promise<string> => {
@@ -210,7 +223,25 @@ async function backupLibrarianState(workspaceRoot: string, fromVersion: number):
   return backupDir;
 }
 
-export async function applyMigrations(db: Database.Database, workspaceRoot?: string): Promise<LibrarianSchemaMigrationReportV1 | null> {
+function resolveMigrationWorkspaceRoot(options: ApplyMigrationsOptions = {}): string | null {
+  if (!options.workspaceRoot) return null;
+  if (!options.dbPath) return options.workspaceRoot;
+
+  const workspaceRoot = path.resolve(options.workspaceRoot);
+  const librarianDir = path.join(workspaceRoot, '.librarian');
+  const dbPath = path.resolve(options.dbPath);
+  const relative = path.relative(librarianDir, dbPath);
+  if (!relative || relative === '') return workspaceRoot;
+  if (relative.startsWith(`..${path.sep}`) || relative === '..') {
+    return null;
+  }
+  return workspaceRoot;
+}
+
+export async function applyMigrations(
+  db: Database.Database,
+  options: ApplyMigrationsOptions = {}
+): Promise<LibrarianSchemaMigrationReportV1 | null> {
   const fromVersion = readSchemaVersion(db);
   if (fromVersion > SCHEMA_VERSION) {
     throw new Error(
@@ -219,13 +250,27 @@ export async function applyMigrations(db: Database.Database, workspaceRoot?: str
   }
   const pending = MIGRATIONS.filter((migration) => migration.version > fromVersion);
   if (!pending.length) return noResult();
-  let backupPath: string | null = null;
-  if (workspaceRoot) {
-    backupPath = await backupLibrarianState(workspaceRoot, fromVersion);
-  }
   const applied: AppliedMigration[] = [];
+  const executablePending: MigrationDefinition[] = [];
+  for (const migration of pending) {
+    const sql = await loadMigrationSql(migration.file);
+    if (isMigrationPreapplied(db, migration)) {
+      writeSchemaVersion(db, migration.version);
+      applied.push({ version: migration.version, name: migration.name, checksum: hashSql(sql) });
+      continue;
+    }
+    executablePending.push(migration);
+  }
+  if (!executablePending.length) {
+    return noResult();
+  }
+  const migrationWorkspaceRoot = resolveMigrationWorkspaceRoot(options);
+  let backupPath: string | null = null;
+  if (migrationWorkspaceRoot) {
+    backupPath = await backupLibrarianState(migrationWorkspaceRoot, fromVersion);
+  }
   try {
-    for (const migration of pending) {
+    for (const migration of executablePending) {
       const sql = await loadMigrationSql(migration.file);
       db.exec(sql);
       writeSchemaVersion(db, migration.version);
@@ -238,18 +283,18 @@ export async function applyMigrations(db: Database.Database, workspaceRoot?: str
       : 'No backup was available; run `librarian bootstrap --force` to rebuild.';
     throw new Error(`Schema migration failed: ${baseMessage}. ${backupHint}`);
   }
-  if (!workspaceRoot) return noResult();
+  if (!migrationWorkspaceRoot) return noResult();
   const report: LibrarianSchemaMigrationReportV1 = {
     kind: 'LibrarianSchemaMigrationReport.v1',
     schema_version: 1,
     created_at: new Date().toISOString(),
-    canon: await computeCanonRef(workspaceRoot),
+    canon: await computeCanonRef(migrationWorkspaceRoot),
     environment: computeEnvironmentRef(),
-    workspace: workspaceRoot,
+    workspace: migrationWorkspaceRoot,
     from_version: fromVersion,
-    to_version: pending[pending.length - 1].version,
+    to_version: applied[applied.length - 1].version,
     applied,
   };
-  await writeMigrationReport(workspaceRoot, report);
+  await writeMigrationReport(migrationWorkspaceRoot, report);
   return report;
 }

--- a/src/api/onboarding_recovery.ts
+++ b/src/api/onboarding_recovery.ts
@@ -7,6 +7,7 @@ import { createSqliteStorage } from '../storage/sqlite_storage.js';
 import {
   attemptStorageRecovery,
   cleanupWorkspaceLocks,
+  recoverPrimaryFromViableSnapshot,
   isRecoverableStorageError,
 } from '../storage/storage_recovery.js';
 import { checkAllProviders } from './provider_check.js';
@@ -31,6 +32,9 @@ async function resolveDbPathForWorkspace(workspaceRoot: string): Promise<string>
 
   try {
     await fs.access(sqlitePath);
+    await recoverPrimaryFromViableSnapshot(sqlitePath, {
+      additionalCandidates: [legacyPath],
+    });
     return sqlitePath;
   } catch {
     // Continue to legacy checks.

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -2,6 +2,7 @@
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
 import { randomUUID } from 'node:crypto';
+import { glob } from 'glob';
 import type {
   LibrarianStorage,
   SimilarityResult,
@@ -56,6 +57,7 @@ import type { QueryRunner, SimilarMatch } from './query_interface.js';
 import type { EvidenceRef } from './evidence.js';
 import { emptyArray, noResult } from './empty_values.js';
 import { safeJsonParse } from '../utils/safe_json.js';
+import { getLanguageFromPath } from '../utils/language.js';
 import { checkProviderSnapshot, ProviderUnavailableError } from './provider_check.js';
 import { checkExtractionSnapshot } from './extraction_gate.js';
 import { ensureDailyModelSelection } from '../adapters/model_policy.js';
@@ -240,6 +242,7 @@ import {
 } from './query_pack_postprocessing.js';
 import {
   buildQueryCacheKey,
+  buildQueryCacheVersionPrefix,
   buildSemanticCacheScopeSignature,
   classifySemanticCacheCategory,
   computeSemanticIntentSimilarity,
@@ -501,6 +504,25 @@ const HINT_LOW_CONFIDENCE_THRESHOLD = q(
   [0, 1],
   'Hint threshold for low-confidence results.'
 );
+const FILESYSTEM_FALLBACK_LIMIT = 6;
+const FILESYSTEM_FALLBACK_GLOB = 'src/**/*.{ts,tsx,js,jsx,mjs,cjs}';
+const FILESYSTEM_FALLBACK_STOP_WORDS = new Set([
+  'the', 'how', 'does', 'what', 'where', 'when', 'why', 'work', 'works', 'working',
+  'implemented', 'implementation', 'defined', 'located', 'handled', 'handling', 'across',
+  'codebase', 'project', 'file', 'files', 'stage', 'stages', 'into', 'from', 'with',
+  'that', 'this', 'those', 'these', 'its', 'their', 'there', 'about',
+]);
+const FILESYSTEM_FALLBACK_DEPRIORITIZED_TERMS = new Set([
+  'dead',
+  'legacy',
+  'deprecated',
+  'archive',
+  'archived',
+  'obsolete',
+  'old',
+]);
+const FILESYSTEM_FALLBACK_DEPRIORITIZED_PATH_SEGMENTS = /(^|\/)(dead|legacy|deprecated|archive|archived|obsolete|old)(\/|$)/u;
+const FILESYSTEM_FALLBACK_PREFERRED_PATH_SEGMENTS = /(^|\/)(live|active|current|canonical|primary)(\/|$)/u;
 
 // ============================================================================
 // META-QUERY DETECTION FOR DOCUMENTATION ROUTING
@@ -642,6 +664,10 @@ export function classifyQueryIntent(intent: string): QueryClassification {
   const featureLocationMatches = FEATURE_LOCATION_PATTERNS.filter(p => p.test(intent)).length;
   const isFeatureLocationQuery = featureLocationMatches > 0 && !isTestQuery;
   const featureTarget = isFeatureLocationQuery ? extractFeatureTarget(intent) : undefined;
+  const hasStrongImplementationLocationSignal =
+    implementationSeekingMatches > 0
+    || isFeatureLocationQuery
+    || /\bwhere\s+is\b.*\b(implemented|defined|located)\b/i.test(intent);
 
   // Check for code review queries - asking for code review or issue detection
   const codeReviewMatches = CODE_REVIEW_QUERY_PATTERNS.filter(p => p.test(intent)).length;
@@ -672,8 +698,19 @@ export function classifyQueryIntent(intent: string): QueryClassification {
   const isProjectUnderstanding = projectUnderstandingMatches > 0 && !isTestQuery && !isWhyQuery && !isArchitectureOverviewQuery;
 
   // Test queries take priority and exclude other query types
-  const isMetaQuery = (metaMatches > 0 && metaMatches >= codeMatches && !isTestQuery && !isWhyQuery) || isProjectUnderstanding;
-  const isCodeQuery = codeMatches > 0 && codeMatches > metaMatches && !isTestQuery && !isProjectUnderstanding && !isWhyQuery;
+  const isMetaQuery = (
+    metaMatches > 0
+    && metaMatches >= codeMatches
+    && !hasStrongImplementationLocationSignal
+    && !isTestQuery
+    && !isWhyQuery
+  ) || isProjectUnderstanding;
+  const isCodeQuery =
+    codeMatches > 0
+    && (codeMatches > metaMatches || hasStrongImplementationLocationSignal)
+    && !isTestQuery
+    && !isProjectUnderstanding
+    && !isWhyQuery;
   const isDefinitionQuery = definitionMatches > 0 && !isTestQuery;
   const isEntryPointQuery = entryPointMatches > 0 && !isTestQuery && !isArchitectureOverviewQuery;
 
@@ -1159,13 +1196,15 @@ export async function queryLibrarian(
       });
     }
 
-    // FAIL-FAST: Verify storage has indexed data before running queries
-    // If bootstrap ran but indexed nothing, queries will return empty/useless results
     const stats = await storage.getStats();
     if (stats.totalFunctions === 0 && stats.totalModules === 0) {
-      throw new Error(
-        'unverified_by_trace(empty_storage): Cannot query librarian - no functions or modules indexed. ' +
-        'Bootstrap may have failed silently or was not run. Run bootstrapProject() first with valid LLM/embedding providers configured.'
+      recordCoverageGap(
+        'semantic_retrieval',
+        'Persistent index is empty; falling back to direct filesystem retrieval.',
+        'significant'
+      );
+      disclosures.push(
+        'unverified_by_trace(empty_storage): Persistent index is empty; using direct filesystem retrieval until bootstrap is repaired.'
       );
     }
 
@@ -2055,7 +2094,7 @@ export async function queryLibrarian(
     ? Math.exp(finalPacks.reduce((sum, p) => sum + Math.log(Math.max(0.01, p.confidence)), 0) / finalPacks.length)
     : 0;
   const indexAssessment = assessIndexState(indexState);
-  if (indexAssessment.confidenceCap !== null) {
+  if (!packStageResult.usedFilesystemFallback && indexAssessment.confidenceCap !== null) {
     totalConfidence = Math.min(totalConfidence, indexAssessment.confidenceCap);
   }
 
@@ -2271,6 +2310,9 @@ export async function queryLibrarian(
     recordCoverageGap,
     explanationParts,
     synthesisEnabled,
+    preferQuickSynthesis: coverageGaps.some((gap) =>
+      /persistent index is empty|vector_index_empty|index not initialized/i.test(gap)
+    ),
     workspaceRoot,
   });
   let synthesis = synthesisStageResult.synthesis;
@@ -3414,7 +3456,7 @@ async function runCandidatePackStage(options: {
   recordCoverageGap: RecordCoverageGap;
   explanationParts: string[];
   version: LibrarianVersion;
-}): Promise<{ allPacks: ContextPack[] }> {
+}): Promise<{ allPacks: ContextPack[]; usedFilesystemFallback: boolean }> {
   const {
     storage,
     query,
@@ -3428,30 +3470,39 @@ async function runCandidatePackStage(options: {
     version,
   } = options;
   const candidatePacks = await collectCandidatePacks(storage, candidates, query.depth);
+  let usedFilesystemFallback = false;
   if (candidatePacks.length && candidates.length) {
     explanationParts.push(`Added ${candidatePacks.length} packs from semantic + graph candidates.`);
   }
   const allPacks = dedupePacks([...directPacks, ...candidatePacks]);
   if (!allPacks.length) {
     const fallbackStage = stageTracker.start('fallback', 1);
-    const fallbackMinConfidence = version.qualityTier === 'mvp'
-      ? FALLBACK_MIN_CONFIDENCE_MVP
-      : FALLBACK_MIN_CONFIDENCE_FULL;
-    let fallbackCandidates = await storage.getContextPacks({ minConfidence: fallbackMinConfidence, limit: FALLBACK_CANDIDATE_LIMIT });
-    if (!fallbackCandidates.length) fallbackCandidates = await storage.getContextPacks({ limit: FALLBACK_CANDIDATE_LIMIT });
-    const fallback = rankHeuristicFallbackPacks(fallbackCandidates, query.intent ?? '').slice(0, FALLBACK_RESULT_LIMIT);
-    if (fallback.length) {
-      allPacks.push(...fallback);
-      explanationParts.push('Applied heuristic fallback ranking (lexical + outcome-weighted) because semantic match was unavailable.');
-      stageTracker.finish(fallbackStage, { outputCount: fallback.length, filteredCount: 0 });
+    const filesystemFallback = await collectFilesystemFallbackPacks(workspaceRoot, query.intent ?? '', version);
+    if (filesystemFallback.length) {
+      allPacks.push(...filesystemFallback);
+      usedFilesystemFallback = true;
+      explanationParts.push('Applied filesystem lexical fallback because indexed packs were unavailable.');
+      stageTracker.finish(fallbackStage, { outputCount: filesystemFallback.length, filteredCount: 0 });
     } else {
-      recordCoverageGap(
-        'fallback',
-        'No context packs available from storage.',
-        'significant',
-        'Run bootstrap or lower the minimum confidence threshold.'
-      );
-      stageTracker.finish(fallbackStage, { outputCount: 0, filteredCount: 0, status: 'failed' });
+      const fallbackMinConfidence = version.qualityTier === 'mvp'
+        ? FALLBACK_MIN_CONFIDENCE_MVP
+        : FALLBACK_MIN_CONFIDENCE_FULL;
+      let fallbackCandidates = await storage.getContextPacks({ minConfidence: fallbackMinConfidence, limit: FALLBACK_CANDIDATE_LIMIT });
+      if (!fallbackCandidates.length) fallbackCandidates = await storage.getContextPacks({ limit: FALLBACK_CANDIDATE_LIMIT });
+      const fallback = rankHeuristicFallbackPacks(fallbackCandidates, query.intent ?? '').slice(0, FALLBACK_RESULT_LIMIT);
+      if (fallback.length) {
+        allPacks.push(...fallback);
+        explanationParts.push('Applied heuristic fallback ranking (lexical + outcome-weighted) because semantic match was unavailable.');
+        stageTracker.finish(fallbackStage, { outputCount: fallback.length, filteredCount: 0 });
+      } else {
+        recordCoverageGap(
+          'fallback',
+          'No context packs available from storage.',
+          'significant',
+          'Run bootstrap or lower the minimum confidence threshold.'
+        );
+        stageTracker.finish(fallbackStage, { outputCount: 0, filteredCount: 0, status: 'failed' });
+      }
     }
   }
   if (directPacks.length) {
@@ -3470,7 +3521,7 @@ async function runCandidatePackStage(options: {
     );
     explanationParts.push(`Filtered ${workspaceScoped.dropped} out-of-workspace packs.`);
   }
-  return { allPacks: workspaceScoped.packs };
+  return { allPacks: workspaceScoped.packs, usedFilesystemFallback };
 }
 
 function rankHeuristicFallbackPacks(candidates: ContextPack[], intent: string): ContextPack[] {
@@ -3549,6 +3600,153 @@ function rankHeuristicFallbackPacks(candidates: ContextPack[], intent: string): 
       || right.pack.accessCount - left.pack.accessCount
     )
     .map((entry) => entry.pack);
+}
+
+async function collectFilesystemFallbackPacks(
+  workspaceRoot: string,
+  intent: string,
+  version: LibrarianVersion,
+): Promise<ContextPack[]> {
+  const terms = tokenize(intent)
+    .filter((term) => term.length >= 3 && !FILESYSTEM_FALLBACK_STOP_WORDS.has(term));
+  if (terms.length === 0) return [];
+  const seeksDeprioritizedPaths = terms.some((term) => FILESYSTEM_FALLBACK_DEPRIORITIZED_TERMS.has(term));
+
+  const files = await glob(FILESYSTEM_FALLBACK_GLOB, {
+    cwd: workspaceRoot,
+    absolute: true,
+    nodir: true,
+    follow: false,
+    ignore: ['**/__tests__/**', '**/*.test.*', '**/*.system.*', '**/*.d.ts'],
+  }).catch(() => []);
+  if (files.length === 0) return [];
+
+  const scored = await Promise.all(files.map(async (absolutePath) => {
+    const relativePath = path.relative(workspaceRoot, absolutePath).replace(/\\/g, '/');
+    const basename = path.basename(relativePath, path.extname(relativePath)).toLowerCase();
+    const pathLower = relativePath.toLowerCase();
+    let content = '';
+    try {
+      content = await fs.readFile(absolutePath, 'utf8');
+    } catch {
+      return null;
+    }
+
+    const exports = extractExportNames(content);
+    const exportTerms = new Set(exports.flatMap((name) => tokenize(name)));
+    const contentLower = content.toLowerCase();
+    let score = pathLower.startsWith('src/api/') ? 2 : 0;
+    if (FILESYSTEM_FALLBACK_PREFERRED_PATH_SEGMENTS.test(pathLower)) {
+      score += 2;
+    }
+    if (!seeksDeprioritizedPaths && FILESYSTEM_FALLBACK_DEPRIORITIZED_PATH_SEGMENTS.test(pathLower)) {
+      score -= 18;
+    }
+    if (!seeksDeprioritizedPaths && /\b(dead code|legacy|deprecated|archived|obsolete)\b/u.test(contentLower)) {
+      score -= 8;
+    }
+    const matchedTerms = new Set<string>();
+    for (const term of terms) {
+      let termScore = 0;
+      if (exportTerms.has(term)) termScore = Math.max(termScore, 10);
+      if (basename === term) termScore = Math.max(termScore, 12);
+      if (basename.startsWith(term)) termScore = Math.max(termScore, 8);
+      if (basename.includes(term)) termScore = Math.max(termScore, 5);
+      if (pathLower.includes(`/${term}/`) || pathLower.includes(`_${term}`) || pathLower.includes(`${term}_`)) {
+        termScore = Math.max(termScore, 4);
+      }
+      if (contentLower.includes(term)) {
+        termScore = Math.max(termScore, 3);
+      }
+      if (termScore > 0) {
+        score += termScore;
+        matchedTerms.add(term);
+      }
+    }
+
+    if (matchedTerms.size >= 2) {
+      score += matchedTerms.size * 3;
+    }
+    if (score <= 0) return null;
+
+    const snippet = buildFilesystemFallbackSnippet(relativePath, content, terms);
+    return {
+      relativePath,
+      score,
+      matchedTerms: Array.from(matchedTerms.values()),
+      exports,
+      snippet,
+    };
+  }));
+
+  const ranked = scored
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+    .sort((left, right) =>
+      right.score - left.score
+      || right.matchedTerms.length - left.matchedTerms.length
+      || left.relativePath.localeCompare(right.relativePath)
+    )
+    .slice(0, FILESYSTEM_FALLBACK_LIMIT);
+  const highestScore = ranked[0]?.score ?? 0;
+  const lowestScore = ranked.at(-1)?.score ?? highestScore;
+  const scoreSpread = Math.max(1, highestScore - lowestScore);
+
+  return ranked
+    .map((entry) => {
+      const relativeScore = ranked.length === 1
+        ? 0.75
+        : (entry.score - lowestScore) / scoreSpread;
+      const confidence = 0.45 + (relativeScore * 0.35);
+      return {
+      packId: `filesystem:${entry.relativePath}`,
+      packType: 'module_context' as ContextPackType,
+      targetId: `filesystem:${entry.relativePath}`,
+      summary: `${entry.relativePath} matches ${entry.matchedTerms.join(', ')}`,
+      keyFacts: [
+        `File: ${entry.relativePath}`,
+        `Matched terms: ${entry.matchedTerms.join(', ')}`,
+        ...(entry.exports.length > 0 ? [`Exports: ${entry.exports.join(', ')}`] : []),
+      ],
+      codeSnippets: entry.snippet ? [entry.snippet] : [],
+      relatedFiles: [entry.relativePath],
+      confidence,
+      createdAt: new Date(),
+      accessCount: 0,
+      lastOutcome: 'unknown',
+      successCount: 0,
+      failureCount: 0,
+      version,
+      invalidationTriggers: [entry.relativePath],
+      };
+    });
+}
+
+function buildFilesystemFallbackSnippet(
+  relativePath: string,
+  content: string,
+  terms: string[],
+): ContextPack['codeSnippets'][number] | null {
+  const lines = content.split(/\r?\n/);
+  if (lines.length === 0) return null;
+  const lowerTerms = terms.map((term) => term.toLowerCase());
+  let matchIndex = lines.findIndex((line) => lowerTerms.some((term) => line.toLowerCase().includes(term)));
+  if (matchIndex < 0) {
+    matchIndex = 0;
+  }
+  const startLine = Math.max(1, matchIndex - 2 + 1);
+  const endLine = Math.min(lines.length, matchIndex + 3 + 1);
+  return {
+    filePath: relativePath,
+    startLine,
+    endLine,
+    content: lines.slice(startLine - 1, endLine).join('\n'),
+    language: getLanguageFromPath(relativePath, 'plaintext'),
+  };
+}
+
+function extractExportNames(content: string): string[] {
+  const matches = Array.from(content.matchAll(/export\s+(?:async\s+)?(?:function|class|const|let|type|interface)\s+([A-Za-z0-9_]+)/g));
+  return matches.slice(0, 6).map((match) => match[1]);
 }
 
 // ============================================================================
@@ -5498,6 +5696,7 @@ async function runSynthesisStage(options: {
   recordCoverageGap: RecordCoverageGap;
   explanationParts: string[];
   synthesisEnabled: boolean;
+  preferQuickSynthesis?: boolean;
   synthesisTimeoutMs?: number;
   workspaceRoot?: string;
   resolveWorkspaceRootFn?: typeof resolveWorkspaceRoot;
@@ -5513,6 +5712,7 @@ async function runSynthesisStage(options: {
     recordCoverageGap,
     explanationParts,
     synthesisEnabled,
+    preferQuickSynthesis,
     synthesisTimeoutMs,
     workspaceRoot,
     resolveWorkspaceRootFn,
@@ -5539,8 +5739,9 @@ async function runSynthesisStage(options: {
     }
     try {
       const forceSummarySynthesis = query.forceSummarySynthesis === true;
+      const shouldPreferQuickSynthesis = preferQuickSynthesis === true;
       // Use quick synthesis for simple queries when possible
-      if (forceSummarySynthesis || shouldQuickAnswer(query, finalPacks)) {
+      if (forceSummarySynthesis || shouldPreferQuickSynthesis || shouldQuickAnswer(query, finalPacks)) {
         try {
           const quickAnswer = buildQuickAnswer(query, finalPacks);
           synthesis = {
@@ -5551,9 +5752,13 @@ async function runSynthesisStage(options: {
             uncertainties: quickAnswer.uncertainties,
           };
           synthesisMode = 'heuristic';
-          explanationParts.push('Quick synthesis from pack summaries.');
+          explanationParts.push(
+            shouldPreferQuickSynthesis && !forceSummarySynthesis
+              ? 'Quick synthesis from pack summaries due to degraded retrieval state.'
+              : 'Quick synthesis from pack summaries.'
+          );
         } catch (quickError) {
-          if (!forceSummarySynthesis) {
+          if (!(forceSummarySynthesis || shouldPreferQuickSynthesis)) {
             throw quickError;
           }
           const topPack = finalPacks
@@ -5761,7 +5966,7 @@ async function trySemanticCacheLookup(options: {
   const threshold = SEMANTIC_CACHE_THRESHOLDS[category];
   const targetIntent = normalizeIntentForCache(intent);
   const targetScope = buildSemanticCacheScopeSignature(options.query);
-  const versionPrefix = `${options.version.string}:${options.version.indexedAt?.getTime?.() ?? 0}|`;
+  const versionPrefix = `${buildQueryCacheVersionPrefix(options.version)}|`;
   const candidates = await cacheStore.getRecentQueryCacheEntries(SEMANTIC_CACHE_CANDIDATE_LIMIT);
 
   let best: { key: string; similarity: number } | null = null;
@@ -6536,9 +6741,16 @@ async function injectFilenameCandidates(
   existingCandidates: Candidate[],
   storage: LibrarianStorage,
 ): Promise<{ candidates: Candidate[]; added: number }> {
-  const stopWords = new Set(['the', 'how', 'does', 'what', 'work', 'and', 'this', 'that', 'with', 'for', 'from', 'into', 'are', 'is']);
-  const terms = intent.toLowerCase().split(/\s+/)
-    .filter(t => t.length >= 3 && !stopWords.has(t));
+  const stopWords = new Set([
+    'the', 'how', 'does', 'what', 'work', 'and', 'this', 'that', 'with', 'for', 'from', 'into',
+    'are', 'is', 'where', 'implemented', 'defined', 'located', 'handled', 'across', 'codebase',
+    'stage', 'stages', 'feature', 'files', 'file', 'its',
+  ]);
+  const terms = Array.from(new Set(
+    intent.toLowerCase().split(/\s+/)
+      .filter(t => t.length >= 3 && !stopWords.has(t))
+      .flatMap((term) => term.endsWith('s') && term.length > 4 ? [term, term.slice(0, -1)] : [term])
+  ));
   if (terms.length === 0) return { candidates: existingCandidates, added: 0 };
 
   const existingIds = new Set(existingCandidates.map(c => c.entityId));
@@ -6609,6 +6821,21 @@ async function injectFilenameCandidates(
 
     // Get functions from matching files and inject as candidates
     for (const filePath of matchingPaths) {
+      const moduleRecord = await storage.getModuleByPath(filePath).catch(() => null);
+      if (moduleRecord && !existingIds.has(moduleRecord.id)) {
+        injected.push({
+          entityId: moduleRecord.id,
+          entityType: 'module',
+          path: moduleRecord.path,
+          semanticSimilarity: 0.52,
+          confidence: moduleRecord.confidence ?? 0.6,
+          recency: 0.5,
+          pagerank: 0,
+          centrality: 0,
+          communityId: null,
+        });
+        existingIds.add(moduleRecord.id);
+      }
       const fns = await storage.getFunctionsByPath(filePath);
       // Prefer functions whose names match query terms (most relevant to the question),
       // then fall back to the longest function (likely the main export)
@@ -7024,6 +7251,10 @@ async function collectCandidatePacks(storage: LibrarianStorage, candidates: Cand
       const jitPack = await synthesizeFunctionPack(storage, candidate);
       if (jitPack) packs.push(jitPack);
     }
+    if (!foundPack && candidate.entityType === 'module') {
+      const jitPack = await synthesizeModulePack(storage, candidate);
+      if (jitPack) packs.push(jitPack);
+    }
   }
   return dedupePacks(packs);
 }
@@ -7064,6 +7295,80 @@ async function synthesizeFunctionPack(storage: LibrarianStorage, candidate: Cand
   } catch {
     return null;
   }
+}
+
+async function synthesizeModulePack(storage: LibrarianStorage, candidate: Candidate): Promise<ContextPack | null> {
+  try {
+    const mod = await storage.getModule(candidate.entityId);
+    if (!mod) return null;
+    const filePath = mod.path || candidate.path || '';
+    const functions = filePath ? await storage.getFunctionsByPath(filePath).catch(() => []) : [];
+    const topFunctions = functions
+      .slice()
+      .sort((left, right) => (right.endLine - right.startLine) - (left.endLine - left.startLine))
+      .slice(0, 5)
+      .map((fn) => fn.name);
+    const snippet = await readModuleSnippet(storage, filePath);
+    const keyFacts: string[] = [];
+    if (mod.purpose) keyFacts.push(`Purpose: ${mod.purpose}`);
+    if (topFunctions.length > 0) keyFacts.push(`Top-level routines: ${topFunctions.join(', ')}`);
+    if (mod.exports.length > 0) keyFacts.push(`Exports: ${mod.exports.slice(0, 6).join(', ')}`);
+    if (mod.dependencies.length > 0) keyFacts.push(`Dependencies: ${mod.dependencies.slice(0, 6).join(', ')}`);
+
+    return {
+      packId: `jit_mod_${candidate.entityId.slice(0, 12)}`,
+      packType: 'module_context' as ContextPackType,
+      targetId: candidate.entityId,
+      summary: mod.purpose || `Module ${filePath || candidate.entityId}`,
+      keyFacts,
+      codeSnippets: snippet ? [snippet] : [],
+      relatedFiles: filePath ? [filePath] : [],
+      confidence: Math.max(mod.confidence ?? 0.5, candidate.confidence ?? 0.5),
+      createdAt: new Date(),
+      accessCount: 0,
+      lastOutcome: 'unknown',
+      successCount: 0,
+      failureCount: 0,
+      version: await storage.getVersion() || getCurrentVersion(),
+      invalidationTriggers: filePath ? [filePath] : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function readModuleSnippet(
+  storage: LibrarianStorage,
+  filePath: string,
+): Promise<ContextPack['codeSnippets'][number] | null> {
+  if (!filePath) return null;
+
+  try {
+    const metadata = await storage.getMetadata().catch(() => null);
+    const workspaceRoot = metadata?.workspace ?? process.cwd();
+    const absolutePath = path.isAbsolute(filePath) ? filePath : path.resolve(workspaceRoot, filePath);
+    const content = await fs.readFile(absolutePath, 'utf-8');
+    const lines = content.split(/\r?\n/).slice(0, 40);
+    if (lines.length === 0) return null;
+    return {
+      filePath,
+      startLine: 1,
+      endLine: lines.length,
+      content: lines.join('\n'),
+      language: getLanguageFromFilePath(filePath),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getLanguageFromFilePath(filePath: string): string {
+  if (filePath.endsWith('.ts') || filePath.endsWith('.tsx')) return 'typescript';
+  if (filePath.endsWith('.js') || filePath.endsWith('.jsx') || filePath.endsWith('.mjs') || filePath.endsWith('.cjs')) return 'javascript';
+  if (filePath.endsWith('.py')) return 'python';
+  if (filePath.endsWith('.rs')) return 'rust';
+  if (filePath.endsWith('.go')) return 'go';
+  return 'text';
 }
 
 /**
@@ -7447,6 +7752,7 @@ export const __testing = {
   computeSemanticIntentSimilarity,
   buildSemanticCacheScopeSignature,
   collectDirectPacks,
+  collectCandidatePacks,
   buildHydePrompt,
   normalizeHydeExpansion,
   buildIdentifierExpansionVariants,
@@ -7457,6 +7763,7 @@ export const __testing = {
   isCallerProbeIntent,
   resolveCandidateMaterializationLimit,
   capCandidatesForMaterialization,
+  injectFilenameCandidates,
 };
 
 /**

--- a/src/api/query_cache_store_utils.ts
+++ b/src/api/query_cache_store_utils.ts
@@ -23,6 +23,7 @@ export type QueryCacheStore = LibrarianStorage & {
 
 const QUERY_CACHE_L1_LIMIT = 100;
 const QUERY_CACHE_L2_LIMIT = 1000;
+const MIN_CACHEABLE_CONFIDENCE = 0.45;
 const queryCacheByStorage = new WeakMap<LibrarianStorage, HierarchicalMemory<CachedResponse>>();
 
 export function getQueryCache(storage: LibrarianStorage): HierarchicalMemory<CachedResponse> {
@@ -54,8 +55,27 @@ export async function setCachedQuery(
   storage: LibrarianStorage,
   query: LibrarianQuery
 ): Promise<void> {
+  if (!isCacheableQueryResponse(response)) {
+    return;
+  }
   const cache = getQueryCache(storage);
   await cache.set(key, response, resolveQueryCacheTier(query));
+}
+
+export function isCacheableQueryResponse(response: CachedResponse): boolean {
+  if (!Array.isArray(response.packs) || response.packs.length === 0) {
+    return false;
+  }
+  if (response.retrievalInsufficient === true) {
+    return false;
+  }
+  if (response.retrievalStatus === 'insufficient') {
+    return false;
+  }
+  if (typeof response.totalConfidence === 'number' && response.totalConfidence < MIN_CACHEABLE_CONFIDENCE) {
+    return false;
+  }
+  return true;
 }
 
 async function readPersistentCache(storage: LibrarianStorage, key: string): Promise<CachedResponse | null> {
@@ -73,6 +93,7 @@ async function readPersistentCache(storage: LibrarianStorage, key: string): Prom
   }
   const parsed = deserializeCachedResponse(entry.response);
   if (!parsed) return noResult();
+  if (!isCacheableQueryResponse(parsed)) return noResult();
   return parsed;
 }
 

--- a/src/api/query_intent_patterns.ts
+++ b/src/api/query_intent_patterns.ts
@@ -256,11 +256,11 @@ export const CODE_REVIEW_QUERY_PATTERNS: RegExp[] = [
  * Examples: "where is authentication implemented", "find the login feature"
  */
 export const FEATURE_LOCATION_PATTERNS: RegExp[] = [
-  /where\s+is\s+(?:the\s+)?(?:\w+)\s+(?:implemented|defined|located)/i,
-  /find\s+(?:the\s+)?(?:\w+)\s+feature/i,
-  /locate\s+(?:the\s+)?(?:implementation|code)\s+(?:for|of)/i,
-  /which\s+files?\s+(?:implement|contain|handle)\s+(?:the\s+)?(?:\w+)/i,
-  /where\s+(?:does|is)\s+(?:the\s+)?(?:\w+)\s+(?:happen|occur|get\s+handled)/i,
+  /where\s+is\s+(?:the\s+)?(?:[\w-]+(?:\s+[\w-]+){0,4})\s+(?:implemented|defined|located)\b/i,
+  /find\s+(?:the\s+)?(?:[\w-]+(?:\s+[\w-]+){0,4})\s+feature\b/i,
+  /locate\s+(?:the\s+)?(?:implementation|code)\s+(?:for|of)\s+(?:the\s+)?(?:[\w-]+(?:\s+[\w-]+){0,4})\b/i,
+  /which\s+files?\s+(?:implement|contain|handle)\s+(?:the\s+)?(?:[\w-]+(?:\s+[\w-]+){0,4})\b/i,
+  /where\s+(?:does|is)\s+(?:the\s+)?(?:[\w-]+(?:\s+[\w-]+){0,4})\s+(?:happen|occur|get\s+handled)\b/i,
   /feature\s+location/i,
 ];
 

--- a/src/api/query_intent_targets.ts
+++ b/src/api/query_intent_targets.ts
@@ -81,17 +81,17 @@ export function extractSecurityCheckTypes(intent: string): string[] {
  */
 export function extractFeatureTarget(intent: string): string | undefined {
   const targetPatterns = [
-    /where\s+is\s+(?:the\s+)?(\w+)\s+(?:implemented|defined|located)/i,
-    /find\s+(?:the\s+)?(\w+)\s+feature/i,
-    /locate\s+(?:the\s+)?(?:implementation|code)\s+(?:for|of)\s+(\w+)/i,
-    /which\s+files?\s+(?:implement|contain|handle)\s+(?:the\s+)?(\w+)/i,
-    /where\s+(?:does|is)\s+(?:the\s+)?(\w+)\s+(?:happen|occur|get\s+handled)/i,
+    /where\s+is\s+(?:the\s+)?([\w-]+(?:\s+[\w-]+){0,4})\s+(?:implemented|defined|located)\b/i,
+    /find\s+(?:the\s+)?([\w-]+(?:\s+[\w-]+){0,4})\s+feature\b/i,
+    /locate\s+(?:the\s+)?(?:implementation|code)\s+(?:for|of)\s+(?:the\s+)?([\w-]+(?:\s+[\w-]+){0,4})\b/i,
+    /which\s+files?\s+(?:implement|contain|handle)\s+(?:the\s+)?([\w-]+(?:\s+[\w-]+){0,4})\b/i,
+    /where\s+(?:does|is)\s+(?:the\s+)?([\w-]+(?:\s+[\w-]+){0,4})\s+(?:happen|occur|get\s+handled)\b/i,
   ];
 
   for (const pattern of targetPatterns) {
     const match = pattern.exec(intent);
     if (match?.[1]) {
-      return match[1];
+      return match[1].trim().replace(/\s+/g, ' ');
     }
   }
   return undefined;

--- a/src/api/query_semantic_cache_utils.ts
+++ b/src/api/query_semantic_cache_utils.ts
@@ -5,6 +5,9 @@ import type {
 } from '../types.js';
 
 export type SemanticCacheCategory = 'lookup' | 'conceptual' | 'diagnostic';
+const QUERY_CACHE_SCHEMA_VERSION = 'qv4';
+const QUERY_CACHE_ROUTING_BEHAVIOR_VERSION = 'route2';
+const QUERY_CACHE_SYNTHESIS_BEHAVIOR_VERSION = 'synth2';
 
 const QUERY_CACHE_STOP_WORDS = new Set([
   'a',
@@ -89,12 +92,22 @@ export function buildQueryCacheKey(
     ].join('|')
     : '';
   const workingFile = query.workingFile ?? '';
-  const versionKey = `${version.string}:${version.indexedAt?.getTime?.() ?? 0}`;
+  const versionKey = buildQueryCacheVersionPrefix(version);
   const embeddingRequirement = query.embeddingRequirement ?? '';
   const methodGuidanceFlag = query.disableMethodGuidance === true ? 1 : 0;
   const forceSummarySynthesisFlag = query.forceSummarySynthesis === true ? 1 : 0;
   const hydeExpansionFlag = query.hydeExpansion === true ? 1 : 0;
   return `${versionKey}|llm:${llmRequirement}|embed:${embeddingRequirement}|syn:${synthesisEnabled ? 1 : 0}|mg:${methodGuidanceFlag}|fs:${forceSummarySynthesisFlag}|hyde:${hydeExpansionFlag}|${query.depth}|${query.taskType ?? ''}|${query.minConfidence ?? ''}|${normalizedIntent}|${files}|wf:${workingFile}|flt:${filterKey}`;
+}
+
+export function buildQueryCacheVersionPrefix(version: LibrarianVersion): string {
+  return [
+    QUERY_CACHE_SCHEMA_VERSION,
+    QUERY_CACHE_ROUTING_BEHAVIOR_VERSION,
+    QUERY_CACHE_SYNTHESIS_BEHAVIOR_VERSION,
+    version.string,
+    version.indexedAt?.getTime?.() ?? 0,
+  ].join(':');
 }
 
 export function classifySemanticCacheCategory(intent: string): SemanticCacheCategory {

--- a/src/api/query_synthesis.ts
+++ b/src/api/query_synthesis.ts
@@ -546,18 +546,39 @@ export function canAnswerFromSummaries(
     intent.startsWith('what does') ||
     intent.startsWith('what is') ||
     intent.includes('purpose of');
+  const isBroadCodebaseQuery =
+    /^(how|what)\s+(is|are)\b/.test(intent)
+    && /\b(codebase|project)\b/.test(intent);
   const isLocationQuery =
     intent.startsWith('where is') ||
     intent.startsWith('where are') ||
     /\b(where|defined|located)\b/.test(intent);
   const isCallerQuery = /\b(callers?|called\s+by|who\s+calls?|what\s+calls?)\b/.test(intent);
 
-  if (!isSimplePurposeQuery && !isLocationQuery && !isCallerQuery) return false;
+  if (!isSimplePurposeQuery && !isBroadCodebaseQuery && !isLocationQuery && !isCallerQuery) return false;
+  const informativePacks = packs.filter((pack) =>
+    (typeof pack.summary === 'string' && pack.summary.trim().length >= 12)
+    || (Array.isArray(pack.keyFacts) && pack.keyFacts.some((fact) => fact.trim().length >= 12))
+  );
+  if (informativePacks.length === 0) return false;
+
+  if (isBroadCodebaseQuery) {
+    const strongPack = informativePacks.some((pack) => pack.confidence >= 0.7);
+    if (strongPack) {
+      return true;
+    }
+    const broadFiles = new Set(
+      informativePacks
+        .flatMap((pack) => pack.relatedFiles ?? [])
+        .map((file) => file.trim())
+        .filter((file) => file.length > 0)
+    );
+    const moderatePacks = informativePacks.filter((pack) => pack.confidence >= 0.3);
+    return broadFiles.size >= 2 && moderatePacks.length >= 2;
+  }
 
   const minConfidence = (isLocationQuery || isCallerQuery) ? 0.6 : 0.7;
   const minSummaryLength = (isLocationQuery || isCallerQuery) ? 10 : 20;
-
-  // Check if we have high-confidence packs with clear summaries
   const goodPacks = packs.filter(
     (p) => p.confidence >= minConfidence && p.summary && p.summary.length >= minSummaryLength
   );
@@ -576,6 +597,9 @@ export function createQuickAnswer(
   const intent = query.intent?.toLowerCase() || '';
   const isLocationQuery = intent.startsWith('where is') || intent.startsWith('where are');
   const isCallerQuery = /\b(callers?|called\s+by|who\s+calls?|what\s+calls?)\b/.test(intent);
+  const broadCodebaseMatch = query.intent?.match(
+    /^(how|what)\s+(is|are)\s+(.+?)\s+(handled|implemented|organized|structured)\s+across\s+the\s+(?:codebase|project)\??$/i
+  );
   const topPack = packs
     .filter((p) => p.summary && p.summary.length > 10)
     .sort((a, b) => b.confidence - a.confidence)[0];
@@ -584,21 +608,30 @@ export function createQuickAnswer(
     throw new Error('No suitable pack for quick answer');
   }
 
-  const files = Array.from(new Set(
-    packs
-      .flatMap((pack) => pack.relatedFiles ?? [])
-      .map((file) => file.trim())
-      .filter((file) => file.length > 0)
-  )).slice(0, 3);
+  const files = collectPreferredDisplayFiles(packs).slice(0, 3);
   const locationSubjectMatch = query.intent?.match(/^where\s+(?:is|are)\s+(.+?)(?:\?|$)/i);
   const locationSubject = locationSubjectMatch?.[1]?.trim();
+  const topFacts = Array.from(new Set(
+    packs
+      .flatMap((pack) => pack.keyFacts ?? [])
+      .map((fact) => fact.trim())
+      .filter((fact) => fact.length > 0)
+  )).slice(0, 3);
 
   let quickAnswerText = topPack.summary;
   if (isLocationQuery && files.length > 0) {
     const subject = locationSubject && locationSubject.length > 0 ? locationSubject : 'the requested logic';
-    quickAnswerText = `${subject} is primarily implemented in ${files.join(', ')}.`;
+    const primaryFile = selectPrimaryLocationFile(query.intent ?? '', packs) ?? files[0];
+    quickAnswerText = `${subject} is primarily implemented in ${primaryFile}.`;
   } else if (isCallerQuery && files.length > 0) {
     quickAnswerText = `Caller relationships are primarily represented in ${files.join(', ')}.`;
+  } else if (broadCodebaseMatch && files.length > 0 && topFacts.length > 0) {
+    const [, , auxiliary, subject, verb] = broadCodebaseMatch;
+    quickAnswerText = `${subject} ${auxiliary} ${verb} across ${files.join(', ')}. Key signals: ${topFacts.join('; ')}.`;
+  } else if (files.length > 0 && topFacts.length > 0) {
+    quickAnswerText = `Relevant implementation is concentrated in ${files.join(', ')}. Key signals: ${topFacts.join('; ')}.`;
+  } else if (files.length > 0) {
+    quickAnswerText = `Relevant implementation is concentrated in ${files.join(', ')}.`;
   }
 
   const queryId = generateQueryId(query);
@@ -619,4 +652,100 @@ export function createQuickAnswer(
     keyInsights: topPack.keyFacts.slice(0, 3),
     uncertainties: ['Answer derived from pack summary without full LLM synthesis'],
   };
+}
+
+function collectPreferredDisplayFiles(packs: ContextPack[]): string[] {
+  const files: string[] = [];
+  const seen = new Set<string>();
+  const add = (candidate: string | undefined) => {
+    if (!candidate) return;
+    const display = extractDisplayFilePath(candidate);
+    if (!display || seen.has(display)) return;
+    seen.add(display);
+    files.push(display);
+  };
+
+  const sorted = packs.slice().sort((left, right) => right.confidence - left.confidence);
+  for (const pack of sorted) {
+    for (const snippet of pack.codeSnippets ?? []) {
+      add(snippet.filePath);
+    }
+    add(pack.targetId);
+    for (const file of pack.relatedFiles ?? []) {
+      add(file);
+    }
+  }
+
+  return files;
+}
+
+function selectPrimaryLocationFile(intent: string, packs: ContextPack[]): string | null {
+  const ranked = packs
+    .map((pack) => ({
+      pack,
+      score: scorePackForLocationIntent(intent, pack),
+    }))
+    .sort((left, right) => right.score - left.score);
+  for (const entry of ranked) {
+    const candidate = collectPreferredDisplayFiles([entry.pack])[0];
+    if (candidate) return candidate;
+  }
+  return null;
+}
+
+function scorePackForLocationIntent(intent: string, pack: ContextPack): number {
+  const text = [
+    pack.targetId,
+    pack.summary,
+    ...(pack.keyFacts ?? []),
+    ...(pack.relatedFiles ?? []),
+    ...(pack.codeSnippets ?? []).map((snippet) => snippet.filePath),
+  ]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join(' ')
+    .toLowerCase();
+
+  let score = pack.confidence;
+  for (const token of extractLocationIntentTokens(intent)) {
+    if (text.includes(token)) {
+      score += token.length >= 6 ? 0.2 : 0.1;
+    }
+  }
+  return score;
+}
+
+function extractLocationIntentTokens(intent: string): string[] {
+  const stopWords = new Set([
+    'where', 'what', 'how', 'is', 'are', 'the', 'its', 'their', 'implemented',
+    'implementation', 'defined', 'located', 'stages', 'stage',
+  ]);
+  return Array.from(new Set(
+    (intent.toLowerCase().match(/[a-z0-9_]+/g) ?? [])
+      .filter((token) => token.length >= 3 && !stopWords.has(token))
+  ));
+}
+
+function extractDisplayFilePath(candidate: string): string | null {
+  const trimmed = candidate.trim().replace(/\\/g, '/');
+  if (!trimmed) return null;
+
+  const targetMatch = trimmed.match(/(.+\.(?:ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|kt|md))(?:[:#].*)?$/i);
+  const pathLike = targetMatch?.[1] ?? trimmed;
+  const anchors = ['/src/', '/docs/', '/scripts/', '/tests/', '/test/'];
+  const lower = pathLike.toLowerCase();
+  for (const anchor of anchors) {
+    const index = lower.lastIndexOf(anchor);
+    if (index >= 0) {
+      return pathLike.slice(index + 1);
+    }
+  }
+
+  if (/^(src|docs|scripts|tests|test)\//i.test(pathLike)) {
+    return pathLike;
+  }
+  if (/\.(ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|kt|md)$/i.test(pathLike)) {
+    return pathLike;
+  }
+
+  return null;
 }

--- a/src/api/retrieval_escalation.ts
+++ b/src/api/retrieval_escalation.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import type { ContextPack, RetrievalStatus } from '../types.js';
 
 export type QueryDepth = 'L0' | 'L1' | 'L2' | 'L3';
@@ -38,6 +39,7 @@ const STOP_WORDS = new Set([
   'modules', 'depend', 'depends', 'module', 'public', 'function', 'functions',
 ]);
 const FILE_EXTENSION_STOP_WORDS = new Set(['ts', 'tsx', 'js', 'jsx', 'mjs', 'cjs', 'py', 'go', 'rs', 'java', 'rb', 'php', 'cs', 'swift']);
+const NON_EXPANDABLE_INTENT_HINTS = /\b(architecture|pipeline|stages|workflow|overview|codebase|project structure|system design)\b/i;
 
 export function computeRetrievalEntropy(packs: Array<Pick<ContextPack, 'confidence'>>): number {
   if (packs.length === 0) return Number(Math.log2(EMPTY_RESULT_ENTROPY_BASE).toFixed(4));
@@ -116,6 +118,7 @@ export function decideRetrievalEscalation(input: RetrievalEscalationInput): Retr
 export function expandEscalationIntent(intent: string, packs: ContextPack[]): string {
   const base = intent.trim();
   if (!base) return intent;
+  if (shouldSkipEscalationExpansion(base)) return intent;
   const existing = new Set(base.toLowerCase().split(/[^a-z0-9_]+/).filter(Boolean));
   const tokens: string[] = [];
 
@@ -154,6 +157,15 @@ export function expandEscalationIntent(intent: string, packs: ContextPack[]): st
   return `${base} ${tokens.join(' ')}`.trim();
 }
 
+function shouldSkipEscalationExpansion(intent: string): boolean {
+  const normalized = intent.trim().toLowerCase();
+  if (!normalized) return true;
+  if (/^where\s+(?:is|are)\b/.test(normalized)) return true;
+  if (/^what\s+is\b/.test(normalized) && NON_EXPANDABLE_INTENT_HINTS.test(normalized)) return true;
+  if (/^how\s+(?:is|are)\b/.test(normalized) && NON_EXPANDABLE_INTENT_HINTS.test(normalized)) return true;
+  return false;
+}
+
 export function buildClarifyingQuestions(intent: string): string[] {
   const trimmed = intent.trim() || 'this issue';
   return [
@@ -173,13 +185,16 @@ function extractIdentifierTokens(signal: string | undefined): string[] {
   const value = String(signal ?? '').trim();
   if (!value) return [];
 
-  const normalized = value
-    .replace(/\\/g, '/')
-    .replace(/[():]/g, ' ')
-    .replace(/\.[A-Za-z0-9]+/g, (match) => {
-      const ext = match.slice(1).toLowerCase();
-      return FILE_EXTENSION_STOP_WORDS.has(ext) ? ' ' : ` ${ext} `;
-    });
+  const normalizedPath = value.replace(/\\/g, '/');
+  const pathSignals = extractPathSignals(normalizedPath);
+  const normalized = pathSignals.length > 0
+    ? pathSignals.join(' ')
+    : normalizedPath
+        .replace(/[():]/g, ' ')
+        .replace(/\.[A-Za-z0-9]+/g, (match) => {
+          const ext = match.slice(1).toLowerCase();
+          return FILE_EXTENSION_STOP_WORDS.has(ext) ? ' ' : ` ${ext} `;
+        });
 
   const parts = normalized
     .split(/[^A-Za-z0-9_]+/)
@@ -195,6 +210,30 @@ function extractIdentifierTokens(signal: string | undefined): string[] {
     }
   }
   return Array.from(output);
+}
+
+function extractPathSignals(value: string): string[] {
+  if (!value.includes('/')) return [];
+
+  const signals: string[] = [];
+  const [pathPart, ...suffixParts] = value.split(':');
+  const trimmedPath = pathPart.trim();
+  if (!trimmedPath) return [];
+
+  const baseName = path.posix.basename(trimmedPath).replace(/\.[A-Za-z0-9]+$/g, '');
+  if (baseName) {
+    signals.push(baseName);
+  }
+
+  const suffix = suffixParts
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0 && !/^\d+$/.test(part))
+    .join(' ');
+  if (suffix) {
+    signals.push(suffix);
+  }
+
+  return signals;
 }
 
 function splitIdentifier(value: string): string[] {

--- a/src/cli/commands/__tests__/query.test.ts
+++ b/src/cli/commands/__tests__/query.test.ts
@@ -44,6 +44,7 @@ vi.mock('../../../storage/sqlite_storage.js', () => ({
     getState: vi.fn().mockResolvedValue(null),
     getStats: vi.fn().mockResolvedValue({
       totalFunctions: 100,
+      totalModules: 10,
       totalEmbeddings: 100,
     }),
     close: vi.fn().mockResolvedValue(undefined),
@@ -84,11 +85,38 @@ describe('queryCommand LLM resolution', () => {
   const prevEnv = { ...process.env };
   let logSpy: ReturnType<typeof vi.spyOn> | null = null;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     delete process.env.LIBRARIAN_LLM_PROVIDER;
     delete process.env.LIBRARIAN_LLM_MODEL;
+
+    const { resolveDbPath } = await import('../../db_path.js');
+    const { createSqliteStorage } = await import('../../../storage/sqlite_storage.js');
+    const { queryLibrarian } = await import('../../../api/query.js');
+    const { isBootstrapRequired, bootstrapProject } = await import('../../../api/bootstrap.js');
+
+    vi.mocked(resolveDbPath).mockResolvedValue('/tmp/librarian.sqlite');
+    vi.mocked(createSqliteStorage).mockReturnValue({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      getState: vi.fn().mockResolvedValue(null),
+      getStats: vi.fn().mockResolvedValue({
+        totalFunctions: 100,
+        totalModules: 10,
+        totalEmbeddings: 100,
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    } as any);
+    vi.mocked(queryLibrarian).mockResolvedValue({
+      intent: 'test',
+      depth: 'L1',
+      totalConfidence: 0.5,
+      cacheHit: false,
+      latencyMs: 10,
+      packs: [],
+    } as any);
+    vi.mocked(isBootstrapRequired).mockResolvedValue({ required: false, reason: 'ok' });
+    vi.mocked(bootstrapProject).mockResolvedValue({ success: true } as any);
   });
 
   afterEach(() => {
@@ -112,7 +140,7 @@ describe('queryCommand LLM resolution', () => {
     expect(process.env.LIBRARIAN_LLM_PROVIDER).toBeUndefined();
   });
 
-  it('auto-bootstraps when required', async () => {
+  it('continues with the existing index snapshot when bootstrap is required but the index is usable', async () => {
     const { queryCommand } = await import('../query.js');
     const { isBootstrapRequired, bootstrapProject, createBootstrapConfig } = await import('../../../api/bootstrap.js');
 
@@ -124,18 +152,44 @@ describe('queryCommand LLM resolution', () => {
       rawArgs: ['query', 'hello world', '--json'],
     });
 
-    expect(bootstrapProject).toHaveBeenCalled();
-    const overrides = vi.mocked(createBootstrapConfig).mock.calls[0]?.[1];
-    expect(overrides?.bootstrapMode).toBe('fast');
-    expect(overrides?.skipLlm).toBe(true);
-    expect(overrides?.timeoutMs).toBe(120000);
+    expect(bootstrapProject).not.toHaveBeenCalled();
+    expect(vi.mocked(createBootstrapConfig).mock.calls).toHaveLength(0);
+  });
+
+  it('skips auto-bootstrap and uses semantic fallback when no usable index exists', async () => {
+    const { queryCommand } = await import('../query.js');
+    const { isBootstrapRequired, bootstrapProject } = await import('../../../api/bootstrap.js');
+    const { createSqliteStorage } = await import('../../../storage/sqlite_storage.js');
+
+    vi.mocked(isBootstrapRequired).mockResolvedValueOnce({ required: true, reason: 'missing' });
+    vi.mocked(createSqliteStorage).mockReturnValueOnce({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      getState: vi.fn().mockResolvedValue(null),
+      getStats: vi.fn().mockResolvedValue({
+        totalFunctions: 0,
+        totalModules: 0,
+        totalEmbeddings: 0,
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    } as any);
+
+    await queryCommand({
+      workspace: '/tmp/workspace',
+      args: [],
+      rawArgs: ['query', 'hello world', '--json'],
+    });
+
+    expect(bootstrapProject).not.toHaveBeenCalled();
   });
 
   it('maps governor wall-time bootstrap timeout to QUERY_TIMEOUT', async () => {
     const { queryCommand } = await import('../query.js');
     const { isBootstrapRequired, bootstrapProject } = await import('../../../api/bootstrap.js');
 
-    vi.mocked(isBootstrapRequired).mockResolvedValueOnce({ required: true, reason: 'missing' });
+    vi.mocked(isBootstrapRequired).mockResolvedValueOnce({
+      required: true,
+      reason: 'Watch state indicates catch-up is required before queries can be trusted',
+    });
     vi.mocked(bootstrapProject).mockRejectedValueOnce(
       new Error('unverified_by_trace(budget_exhausted): Exceeded wall_time budget (health: -0.72)')
     );
@@ -158,18 +212,21 @@ describe('queryCommand LLM resolution', () => {
     await fs.mkdir(path.dirname(dbPath), { recursive: true });
     await fs.writeFile(dbPath, 'corrupt', 'utf8');
     vi.mocked(resolveDbPath).mockResolvedValueOnce(dbPath);
-    vi.mocked(isBootstrapRequired).mockResolvedValueOnce({ required: true, reason: 'missing' });
+    vi.mocked(isBootstrapRequired).mockResolvedValueOnce({
+      required: true,
+      reason: 'Watch state indicates catch-up is required before queries can be trusted',
+    });
 
     const firstStorage = {
       initialize: vi.fn().mockResolvedValue(undefined),
       getState: vi.fn().mockResolvedValue(null),
-      getStats: vi.fn().mockResolvedValue({ totalFunctions: 100, totalEmbeddings: 100 }),
+      getStats: vi.fn().mockResolvedValue({ totalFunctions: 100, totalModules: 10, totalEmbeddings: 100 }),
       close: vi.fn().mockResolvedValue(undefined),
     };
     const secondStorage = {
       initialize: vi.fn().mockResolvedValue(undefined),
       getState: vi.fn().mockResolvedValue(null),
-      getStats: vi.fn().mockResolvedValue({ totalFunctions: 100, totalEmbeddings: 100 }),
+      getStats: vi.fn().mockResolvedValue({ totalFunctions: 100, totalModules: 10, totalEmbeddings: 100 }),
       close: vi.fn().mockResolvedValue(undefined),
     };
     vi.mocked(createSqliteStorage)
@@ -201,6 +258,7 @@ describe('queryCommand LLM resolution', () => {
       required: true,
       reason: 'Watch state indicates catch-up is required before queries can be trusted',
     });
+    vi.mocked(bootstrapProject).mockResolvedValueOnce({ success: true } as any);
 
     // deferred reasons (watch_catchup etc.) no longer throw NOT_BOOTSTRAPPED;
     // they log a warning and fall through to auto-bootstrap so the query can recover.
@@ -424,6 +482,67 @@ describe('queryCommand LLM resolution', () => {
     }
   });
 
+  it('uses the preserved bootstrap snapshot while an active bootstrap lock is held', async () => {
+    const { queryCommand } = await import('../query.js');
+    const { resolveDbPath } = await import('../../db_path.js');
+    const { createSqliteStorage } = await import('../../../storage/sqlite_storage.js');
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'librarian-query-bootstrap-snapshot-'));
+    const librarianDir = path.join(workspace, '.librarian');
+    const sqlitePath = path.join(librarianDir, 'librarian.sqlite');
+    const backupPath = `${sqlitePath}.bak.test`;
+    const bootstrapLockPath = path.join(librarianDir, 'bootstrap.lock');
+    const backupStatePath = path.join(librarianDir, 'bootstrap_artifact_backup.json');
+    const lockHolder = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60000)'], {
+      stdio: 'ignore',
+      detached: false,
+    });
+
+    try {
+      await fs.mkdir(librarianDir, { recursive: true });
+      await fs.writeFile(sqlitePath, 'primary', 'utf8');
+      await fs.writeFile(backupPath, 'backup', 'utf8');
+      await fs.writeFile(
+        bootstrapLockPath,
+        JSON.stringify({
+          pid: lockHolder.pid,
+          startedAt: '2026-03-06T19:29:38.878Z',
+        }),
+        'utf8',
+      );
+      await fs.writeFile(
+        backupStatePath,
+        JSON.stringify({
+          kind: 'BootstrapArtifactBackupState.v1',
+          schema_version: 1,
+          workspace,
+          generation_id: 'snapshot-test',
+          created_at: '2026-03-06T19:29:47.161Z',
+          files: [
+            {
+              original_path: sqlitePath,
+              backup_path: backupPath,
+            },
+          ],
+        }),
+        'utf8',
+      );
+      vi.mocked(resolveDbPath).mockResolvedValueOnce(sqlitePath);
+
+      await queryCommand({
+        workspace,
+        args: [],
+        rawArgs: ['query', 'hello world', '--json'],
+      });
+
+      const storageCall = vi.mocked(createSqliteStorage).mock.calls[0];
+      expect(storageCall?.[0]).toBe(backupPath);
+      expect(storageCall?.[2]).toMatchObject({ useProcessLock: false });
+    } finally {
+      lockHolder.kill('SIGKILL');
+      await fs.rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   it('auto-recovers stale legacy lock artifacts before query execution', async () => {
     const { queryCommand } = await import('../query.js');
     const { resolveDbPath } = await import('../../db_path.js');
@@ -449,8 +568,8 @@ describe('queryCommand LLM resolution', () => {
       });
 
       await expect(fs.access(legacyLockPath)).rejects.toBeDefined();
-      await expect(fs.access(legacyWalPath)).rejects.toBeDefined();
-      await expect(fs.access(legacyShmPath)).rejects.toBeDefined();
+      await expect(fs.access(legacyWalPath)).resolves.toBeUndefined();
+      await expect(fs.access(legacyShmPath)).resolves.toBeUndefined();
     } finally {
       await fs.rm(workspace, { recursive: true, force: true });
     }
@@ -471,13 +590,13 @@ describe('queryCommand LLM resolution', () => {
     const firstStorage = {
       initialize: vi.fn().mockRejectedValueOnce(new Error('database disk image is malformed')),
       getState: vi.fn().mockResolvedValue(null),
-      getStats: vi.fn().mockResolvedValue({ totalFunctions: 100, totalEmbeddings: 100 }),
+      getStats: vi.fn().mockResolvedValue({ totalFunctions: 100, totalModules: 10, totalEmbeddings: 100 }),
       close: vi.fn().mockResolvedValue(undefined),
     };
     const secondStorage = {
       initialize: vi.fn().mockResolvedValue(undefined),
       getState: vi.fn().mockResolvedValue(null),
-      getStats: vi.fn().mockResolvedValue({ totalFunctions: 100, totalEmbeddings: 100 }),
+      getStats: vi.fn().mockResolvedValue({ totalFunctions: 100, totalModules: 10, totalEmbeddings: 100 }),
       close: vi.fn().mockResolvedValue(undefined),
     };
     vi.mocked(createSqliteStorage)
@@ -513,13 +632,13 @@ describe('queryCommand LLM resolution', () => {
     const firstStorage = {
       initialize: vi.fn().mockResolvedValue(undefined),
       getState: vi.fn().mockResolvedValue(null),
-      getStats: vi.fn().mockResolvedValue({ totalFunctions: 100, totalEmbeddings: 100 }),
+      getStats: vi.fn().mockResolvedValue({ totalFunctions: 100, totalModules: 10, totalEmbeddings: 100 }),
       close: vi.fn().mockResolvedValue(undefined),
     };
     const secondStorage = {
       initialize: vi.fn().mockResolvedValue(undefined),
       getState: vi.fn().mockResolvedValue(null),
-      getStats: vi.fn().mockResolvedValue({ totalFunctions: 100, totalEmbeddings: 100 }),
+      getStats: vi.fn().mockResolvedValue({ totalFunctions: 100, totalModules: 10, totalEmbeddings: 100 }),
       close: vi.fn().mockResolvedValue(undefined),
     };
     vi.mocked(createSqliteStorage)
@@ -560,6 +679,7 @@ describe('queryCommand LLM resolution', () => {
       getState: vi.fn().mockResolvedValue(null),
       getStats: vi.fn().mockResolvedValue({
         totalFunctions: 100,
+        totalModules: 10,
         totalEmbeddings: 20,
       }),
       close: vi.fn().mockResolvedValue(undefined),
@@ -642,6 +762,56 @@ describe('queryCommand LLM resolution', () => {
     expect(jsonOutput).toBeDefined();
     const parsed = JSON.parse(jsonOutput ?? '{}');
     expect(parsed.answer).toBe('calculateSecurityDebt computes the risk score.');
+  });
+
+  it('prefers the primary source file in derived location answers', async () => {
+    const { queryCommand } = await import('../query.js');
+    const { queryLibrarian } = await import('../../../api/query.js');
+
+    vi.mocked(queryLibrarian).mockResolvedValueOnce({
+      query: { intent: 'Where is the query pipeline implemented?', depth: 'L1' },
+      totalConfidence: 0.9,
+      cacheHit: false,
+      latencyMs: 10,
+      version: { major: 0, minor: 2, patch: 1, qualityTier: 'full', indexedAt: new Date() },
+      disclosures: [],
+      drillDownHints: [],
+      synthesis: undefined,
+      packs: [
+        {
+          packId: 'p1',
+          packType: 'module_context',
+          targetId: '/tmp/workspace/src/api/query.ts',
+          summary: 'query pipeline module',
+          keyFacts: [],
+          relatedFiles: ['src/storage/types.js', 'src/types.js'],
+          codeSnippets: [
+            {
+              filePath: '/tmp/workspace/src/api/query.ts',
+              startLine: 1,
+              endLine: 5,
+              content: 'export function queryLibrarian() {}',
+              language: 'typescript',
+            },
+          ],
+          confidence: 0.95,
+          createdAt: new Date(),
+          version: { major: 0, minor: 2, patch: 1, qualityTier: 'full', indexedAt: new Date() },
+        },
+      ],
+    } as any);
+
+    await queryCommand({
+      workspace: '/tmp/workspace',
+      args: [],
+      rawArgs: ['query', 'Where is the query pipeline implemented?', '--json'],
+    });
+
+    const jsonOutput = logSpy?.mock.calls.map((call) => String(call[0])).find((line) => line.startsWith('{'));
+    expect(jsonOutput).toBeDefined();
+    const parsed = JSON.parse(jsonOutput ?? '{}');
+    expect(parsed.answer).toContain('src/api/query.ts');
+    expect(parsed.answer).not.toContain('src/storage/types.js');
   });
 
   it('writes JSON output to --out path', async () => {
@@ -964,7 +1134,10 @@ describe('queryCommand LLM resolution', () => {
     const { queryCommand } = await import('../query.js');
     const { isBootstrapRequired, bootstrapProject } = await import('../../../api/bootstrap.js');
 
-    vi.mocked(isBootstrapRequired).mockResolvedValueOnce({ required: true, reason: 'missing' });
+    vi.mocked(isBootstrapRequired).mockResolvedValueOnce({
+      required: true,
+      reason: 'Watch state indicates catch-up is required before queries can be trusted',
+    });
     vi.mocked(bootstrapProject).mockImplementationOnce(
       () => new Promise<never>(() => {})
     );

--- a/src/cli/commands/__tests__/query_bootstrap_fallback.test.ts
+++ b/src/cli/commands/__tests__/query_bootstrap_fallback.test.ts
@@ -41,5 +41,63 @@ describe('query bootstrap fallback helpers', () => {
 
     expect(decision.allowContinue).toBe(false);
   });
-});
 
+  it('continues with semantic fallback when bootstrap is required but the index is empty', async () => {
+    const storage = {
+      getStats: async () => ({
+        totalFunctions: 0,
+        totalModules: 0,
+      }),
+    } as { getStats: () => Promise<{ totalFunctions: number; totalModules: number }> };
+
+    const decision = await __testing.evaluateBootstrapRequirementFallback(
+      storage as never,
+      {
+        reason: 'Previous bootstrap incomplete',
+        allowSemanticFallback: true,
+      }
+    );
+
+    expect(decision.allowContinue).toBe(true);
+    expect(decision.notice).toContain('direct filesystem retrieval');
+  });
+
+  it('continues with the last successful index snapshot when bootstrap repair is pending but the index is usable', async () => {
+    const storage = {
+      getStats: async () => ({
+        totalFunctions: 120,
+        totalModules: 18,
+      }),
+    } as { getStats: () => Promise<{ totalFunctions: number; totalModules: number }> };
+
+    const decision = await __testing.evaluateBootstrapRequirementFallback(
+      storage as never,
+      {
+        reason: 'Previous bootstrap incomplete',
+        allowSemanticFallback: true,
+      }
+    );
+
+    expect(decision.allowContinue).toBe(true);
+    expect(decision.notice).toContain('last successful index snapshot');
+  });
+
+  it('does not continue with semantic fallback for exhaustive/enumeration queries', async () => {
+    const storage = {
+      getStats: async () => ({
+        totalFunctions: 0,
+        totalModules: 0,
+      }),
+    } as { getStats: () => Promise<{ totalFunctions: number; totalModules: number }> };
+
+    const decision = await __testing.evaluateBootstrapRequirementFallback(
+      storage as never,
+      {
+        reason: 'Previous bootstrap incomplete',
+        allowSemanticFallback: false,
+      }
+    );
+
+    expect(decision.allowContinue).toBe(false);
+  });
+});

--- a/src/cli/commands/coverage.ts
+++ b/src/cli/commands/coverage.ts
@@ -84,9 +84,8 @@ export async function coverageCommand(options: CoverageCommandOptions): Promise<
 
   const workspaceRoot = path.resolve(workspace);
   const outputPath = path.resolve(workspaceRoot, values.output as string || DEFAULT_OUTPUT);
-
-  const ucIds = await readUcIds(path.join(workspaceRoot, 'docs', 'archive', 'USE_CASE_MATRIX.md'));
-  const scenarioIds = await readScenarioIds(path.join(workspaceRoot, 'docs', 'archive', 'scenarios.md'));
+  const ucIds = await readUcIds(await resolveCoverageDocPath(workspaceRoot, 'USE_CASE_MATRIX.md'));
+  const scenarioIds = await readScenarioIds(await resolveCoverageDocPath(workspaceRoot, 'scenarios.md'));
 
   if (ucIds.length === 0) {
     throw createError('VALIDATION_FAILED', 'No UC IDs found in USE_CASE_MATRIX.md');
@@ -363,4 +362,20 @@ async function readScenarioIds(filePath: string): Promise<string[]> {
     if (match?.[1]) ids.add(match[1]);
   }
   return Array.from(ids).sort();
+}
+
+async function resolveCoverageDocPath(workspaceRoot: string, fileName: 'USE_CASE_MATRIX.md' | 'scenarios.md'): Promise<string> {
+  const candidates = [
+    path.join(workspaceRoot, 'docs', 'archive', fileName),
+    path.join(workspaceRoot, 'docs', 'librarian', fileName),
+  ];
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // Try the next location.
+    }
+  }
+  throw new Error(`Coverage documentation file not found: ${fileName}`);
 }

--- a/src/cli/commands/query.ts
+++ b/src/cli/commands/query.ts
@@ -39,6 +39,13 @@ export interface QueryCommandOptions {
   rawArgs: string[];
 }
 
+interface QueryReadTarget {
+  dbPath: string;
+  ignoreBootstrapLock: boolean;
+  suppressWrites: boolean;
+  notice?: string;
+}
+
 type QueryStrategyFlag = 'auto' | 'semantic' | 'heuristic';
 type RetrievalStrategy = 'hybrid' | 'semantic' | 'heuristic' | 'degraded';
 type QuerySessionMode = 'start' | 'follow_up' | 'drill_down';
@@ -218,20 +225,25 @@ export async function queryCommand(options: QueryCommandOptions): Promise<void> 
   }
 
   // Initialize storage
-  const dbPath = await resolveDbPath(workspace);
+  const primaryDbPath = await resolveDbPath(workspace);
+  const queryReadTarget = await resolveQueryReadTarget(workspace, primaryDbPath);
+  const dbPath = queryReadTarget.dbPath;
   await runQueryStorageLockPreflight(workspace, dbPath, {
     timeoutMs: lockTimeoutMs,
     retryIntervalMs: STORAGE_LOCK_RETRY_INTERVAL_MS,
     maxRecoveryActions: DEFAULT_QUERY_PREFLIGHT_MAX_RECOVERY_ACTIONS,
     allowConcurrentReads: true,
+    ignoreBootstrapLock: queryReadTarget.ignoreBootstrapLock,
   });
-  let storage = createQueryStorage(dbPath, workspace);
+  let storage = createQueryStorage(dbPath, workspace, {
+    suppressWrites: queryReadTarget.suppressWrites,
+  });
   storage = await withQueryCommandTimeout(
     'initialize',
     effectiveQueryTimeoutMs,
     () => initializeQueryStorageWithRecovery(storage, dbPath, workspace)
   );
-  let bootstrapFallbackNotice: string | undefined;
+  const queryNotices = queryReadTarget.notice ? [queryReadTarget.notice] : [];
   const executeQueryWithRecovery = async (queryPayload: LibrarianQuery): Promise<LibrarianResponse> => {
     try {
       return await withQueryCommandTimeout(
@@ -256,6 +268,12 @@ export async function queryCommand(options: QueryCommandOptions): Promise<void> 
       );
     }
   };
+  const enumerationIntent = sessionRequested
+    ? { isEnumeration: false, confidence: 0, category: undefined }
+    : detectEnumerationIntent(intent);
+  const useEnumeration = explicitEnumerate || (enumerationIntent.isEnumeration && enumerationIntent.confidence >= 0.7);
+  const autoDetectExhaustive = sessionRequested ? false : shouldUseExhaustiveMode(intent);
+  const useExhaustive = explicitExhaustive || autoDetectExhaustive;
   try {
     // Check if bootstrapped - detect current tier and use that as target
     // This allows operation on existing data without requiring upgrade
@@ -270,58 +288,67 @@ export async function queryCommand(options: QueryCommandOptions): Promise<void> 
           buildQueryBootstrapRemediation(bootstrapCheck.reason, deferredReason)
         );
       }
+      const requirementFallback = deferredReason
+        ? { allowContinue: false as const }
+        : await evaluateBootstrapRequirementFallback(storage, {
+          reason: bootstrapCheck.reason,
+          allowSemanticFallback: !useEnumeration && !useExhaustive,
+        });
+      if (requirementFallback.allowContinue) {
+        if (requirementFallback.notice) {
+          queryNotices.push(requirementFallback.notice);
+        }
+        console.error(`[query] ${requirementFallback.notice}`);
+      } else {
       if (deferredReason) {
         const remediation = buildQueryBootstrapRemediation(bootstrapCheck.reason, deferredReason);
         if (typeof process.stderr?.write === 'function') {
           process.stderr.write(`[query] deferred bootstrap reason: ${deferredReason} — falling through to auto-bootstrap\n`);
         }
       }
-      const bootstrapSpinner = createSpinner('Bootstrap required; initializing (fast mode)...');
-      try {
-        let skipEmbeddings = false;
-        const providerCheckSkipped =
-          (process.env.LIBRAINIAN_SKIP_PROVIDER_CHECK ?? process.env.LIBRARIAN_SKIP_PROVIDER_CHECK) === '1';
-        if (providerCheckSkipped) {
-          skipEmbeddings = true;
-        } else {
-          try {
-            const providerStatus = await checkAllProviders({ workspaceRoot: workspace });
-            skipEmbeddings = !providerStatus.embedding.available;
-          } catch {
+        const bootstrapSpinner = createSpinner('Bootstrap required; initializing (fast mode)...');
+        try {
+          let skipEmbeddings = false;
+          const providerCheckSkipped =
+            (process.env.LIBRAINIAN_SKIP_PROVIDER_CHECK ?? process.env.LIBRARIAN_SKIP_PROVIDER_CHECK) === '1';
+          if (providerCheckSkipped) {
             skipEmbeddings = true;
+          } else {
+            try {
+              const providerStatus = await checkAllProviders({ workspaceRoot: workspace });
+              skipEmbeddings = !providerStatus.embedding.available;
+            } catch {
+              skipEmbeddings = true;
+            }
           }
+          const config = createBootstrapConfig(workspace, {
+            bootstrapMode: 'fast',
+            skipLlm: true,
+            skipEmbeddings,
+            timeoutMs: effectiveQueryTimeoutMs,
+          });
+          storage = await executeQueryBootstrapWithRecovery({
+            workspace,
+            dbPath,
+            storage,
+            config,
+            timeoutMs: effectiveQueryTimeoutMs,
+          });
+          bootstrapSpinner.succeed('Bootstrap complete');
+        } catch (error) {
+          const fallback = await evaluateBootstrapFailureFallback(storage, error);
+          if (!fallback.allowContinue) {
+            bootstrapSpinner.fail('Bootstrap failed');
+            throw error;
+          }
+          if (fallback.notice) {
+            queryNotices.push(fallback.notice);
+          }
+          bootstrapSpinner.succeed('Bootstrap validation failed; continuing with existing index');
+          console.error(`[query] ${fallback.notice}`);
         }
-        const config = createBootstrapConfig(workspace, {
-          bootstrapMode: 'fast',
-          skipLlm: true,
-          skipEmbeddings,
-          timeoutMs: effectiveQueryTimeoutMs,
-        });
-        storage = await executeQueryBootstrapWithRecovery({
-          workspace,
-          dbPath,
-          storage,
-          config,
-          timeoutMs: effectiveQueryTimeoutMs,
-        });
-        bootstrapSpinner.succeed('Bootstrap complete');
-      } catch (error) {
-        const fallback = await evaluateBootstrapFailureFallback(storage, error);
-        if (!fallback.allowContinue) {
-          bootstrapSpinner.fail('Bootstrap failed');
-          throw error;
-        }
-        bootstrapFallbackNotice = fallback.notice;
-        bootstrapSpinner.succeed('Bootstrap validation failed; continuing with existing index');
-        console.error(`[query] ${fallback.notice}`);
       }
     }
-
-    // Check if this is an enumeration query (explicit flag or auto-detected)
-    const enumerationIntent = sessionRequested
-      ? { isEnumeration: false, confidence: 0, category: undefined }
-      : detectEnumerationIntent(intent);
-    const useEnumeration = explicitEnumerate || (enumerationIntent.isEnumeration && enumerationIntent.confidence >= 0.7);
 
     if (useEnumeration && enumerationIntent.category) {
       // Run enumeration query - returns COMPLETE lists instead of top-k
@@ -370,10 +397,6 @@ export async function queryCommand(options: QueryCommandOptions): Promise<void> 
         throw error;
       }
     }
-
-    // Check if this is an exhaustive query (explicit flag or auto-detected)
-    const autoDetectExhaustive = sessionRequested ? false : shouldUseExhaustiveMode(intent);
-    const useExhaustive = explicitExhaustive || autoDetectExhaustive;
 
     if (useExhaustive) {
       // Run exhaustive dependency query instead of semantic query
@@ -702,10 +725,10 @@ export async function queryCommand(options: QueryCommandOptions): Promise<void> 
     try {
       const startTime = Date.now();
       const rawResponse = await executeQueryWithRecovery(query);
-      const responseWithBootstrapNotice = bootstrapFallbackNotice
+      const responseWithBootstrapNotice = queryNotices.length > 0
         ? {
             ...rawResponse,
-            coverageGaps: [...(rawResponse.coverageGaps ?? []), bootstrapFallbackNotice],
+            coverageGaps: [...(rawResponse.coverageGaps ?? []), ...queryNotices],
           }
         : rawResponse;
       const { response, droppedCount } = applyPackLimit(responseWithBootstrapNotice, limit);
@@ -898,6 +921,7 @@ interface QueryStorageLockPreflightOptions {
   retryIntervalMs: number;
   maxRecoveryActions: number;
   allowConcurrentReads?: boolean;
+  ignoreBootstrapLock?: boolean;
 }
 
 async function runQueryStorageLockPreflight(
@@ -911,6 +935,7 @@ async function runQueryStorageLockPreflight(
   const retryIntervalMs = Math.max(50, options.retryIntervalMs);
   const maxRecoveryActions = Math.max(1, options.maxRecoveryActions);
   const allowConcurrentReads = options.allowConcurrentReads === true;
+  const ignoreBootstrapLock = options.ignoreBootstrapLock === true;
   const deadline = Date.now() + timeoutMs;
   let nextRecoveryAt = 0;
   let recoveryActionCount = 0;
@@ -929,7 +954,7 @@ async function runQueryStorageLockPreflight(
 
       for (const candidateDbPath of candidateDbPaths) {
         try {
-          const recovery = await attemptStorageRecovery(candidateDbPath);
+          const recovery = await attemptStorageRecovery(candidateDbPath, { mode: 'stale_lock' });
           if (recovery.recovered && recovery.actions.length > 0) {
             recoveryActionCount += recovery.actions.length;
             console.error(
@@ -954,7 +979,9 @@ async function runQueryStorageLockPreflight(
 
     const activeStorageLock = await findActiveStorageLock(lockPaths);
     const activeBootstrapBlockingLock =
-      activeBootstrapLock && activeBootstrapLock.holder.pid !== process.pid
+      !ignoreBootstrapLock
+      && activeBootstrapLock
+      && activeBootstrapLock.holder.pid !== process.pid
         ? activeBootstrapLock
         : null;
     const activeStorageBlockingLock =
@@ -1210,16 +1237,11 @@ function deriveQueryAnswer(response: LibrarianResponse, intent?: string): string
   if (synthesized) return synthesized;
 
   if (isLocationIntent(intent)) {
-    const allFiles = response.packs.flatMap((pack) => pack.relatedFiles ?? []);
-    const nonTestFiles = allFiles.filter((file) => {
-      const normalized = file.toLowerCase();
-      return !normalized.includes('/__tests__/') && !normalized.includes('.test.') && !normalized.includes('.spec.');
-    });
-    const files = Array.from(new Set((nonTestFiles.length > 0 ? nonTestFiles : allFiles).filter(Boolean))).slice(0, 3);
+    const files = collectPreferredAnswerFiles(response.packs).slice(0, 1);
     const subjectMatch = intent?.match(/^where\s+(?:is|are)\s+(.+?)(?:\?|$)/i);
     const subject = subjectMatch?.[1]?.trim() || 'the requested logic';
     if (files.length > 0) {
-      return `${subject} is primarily implemented in ${files.join(', ')}.`;
+      return `${subject} is primarily implemented in ${files[0]}.`;
     }
   }
 
@@ -1233,6 +1255,58 @@ function deriveQueryAnswer(response: LibrarianResponse, intent?: string): string
   const explanation = response.explanation?.trim();
   if (explanation) return explanation;
   return undefined;
+}
+
+function collectPreferredAnswerFiles(packs: LibrarianResponse['packs']): string[] {
+  const files: string[] = [];
+  const seen = new Set<string>();
+  const sorted = packs.slice().sort((left, right) => right.confidence - left.confidence);
+  const add = (candidate: string | undefined) => {
+    if (!candidate) return;
+    const display = extractDisplayAnswerFile(candidate);
+    if (!display || seen.has(display)) return;
+    seen.add(display);
+    files.push(display);
+  };
+
+  for (const pack of sorted) {
+    for (const snippet of pack.codeSnippets ?? []) {
+      add(snippet.filePath);
+    }
+    add(pack.targetId);
+    for (const file of pack.relatedFiles ?? []) {
+      add(file);
+    }
+  }
+
+  return files;
+}
+
+function extractDisplayAnswerFile(candidate: string): string | null {
+  const trimmed = candidate.trim().replace(/\\/g, '/');
+  if (!trimmed) return null;
+  const lower = trimmed.toLowerCase();
+  if (lower.includes('/__tests__/') || lower.includes('.test.') || lower.includes('.spec.')) {
+    return null;
+  }
+
+  const targetMatch = trimmed.match(/(.+\.(?:ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|kt|md))(?:[:#].*)?$/i);
+  const pathLike = targetMatch?.[1] ?? trimmed;
+  const anchors = ['/src/', '/docs/', '/scripts/', '/tests/', '/test/'];
+  const normalized = pathLike.toLowerCase();
+  for (const anchor of anchors) {
+    const index = normalized.lastIndexOf(anchor);
+    if (index >= 0) {
+      return pathLike.slice(index + 1);
+    }
+  }
+  if (/^(src|docs|scripts|tests|test)\//i.test(pathLike)) {
+    return pathLike;
+  }
+  if (/\.(ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|kt|md)$/i.test(pathLike)) {
+    return pathLike;
+  }
+  return null;
 }
 
 async function withQueryCommandTimeout<T>(
@@ -1301,9 +1375,132 @@ async function initializeQueryStorageWithRecovery(
 
 function createQueryStorage(
   dbPath: string,
-  workspace: string
+  workspace: string,
+  options: { suppressWrites?: boolean } = {},
 ): ReturnType<typeof createSqliteStorage> {
-  return createSqliteStorage(dbPath, workspace, QUERY_READ_STORAGE_OPTIONS);
+  const storage = createSqliteStorage(dbPath, workspace, QUERY_READ_STORAGE_OPTIONS);
+  if (options.suppressWrites !== true) {
+    return storage;
+  }
+  return createReadMostlyQueryStorage(storage);
+}
+
+function createReadMostlyQueryStorage(
+  storage: ReturnType<typeof createSqliteStorage>
+): ReturnType<typeof createSqliteStorage> {
+  const noOpAsync = async (): Promise<void> => undefined;
+  const noOpAsyncZero = async (): Promise<number> => 0;
+  const suppressedMethods = new Map<PropertyKey, unknown>([
+    ['setState', noOpAsync],
+    ['recordContextPackAccess', noOpAsync],
+    ['recordQueryAccessLogs', noOpAsync],
+    ['upsertQueryCacheEntry', noOpAsync],
+    ['recordQueryCacheAccess', noOpAsync],
+    ['pruneQueryCache', noOpAsyncZero],
+  ]);
+
+  return new Proxy(storage, {
+    get(target, property) {
+      if (suppressedMethods.has(property)) {
+        return suppressedMethods.get(property);
+      }
+      const value = Reflect.get(target, property, target);
+      if (typeof value === 'function') {
+        return value.bind(target);
+      }
+      return value;
+    },
+  }) as ReturnType<typeof createSqliteStorage>;
+}
+
+interface BootstrapArtifactBackupEntry {
+  original_path: string;
+  backup_path: string;
+}
+
+interface BootstrapArtifactBackupState {
+  kind: 'BootstrapArtifactBackupState.v1';
+  schema_version: 1;
+  workspace: string;
+  generation_id: string;
+  created_at: string;
+  files: BootstrapArtifactBackupEntry[];
+}
+
+async function resolveQueryReadTarget(
+  workspace: string,
+  primaryDbPath: string
+): Promise<QueryReadTarget> {
+  const primaryPath = path.resolve(primaryDbPath);
+  const bootstrapLockState = await reconcileBootstrapWorkspaceLock(workspace);
+  const activeBootstrapHolder = bootstrapLockState.activeHolder;
+  if (!activeBootstrapHolder || activeBootstrapHolder.pid === process.pid) {
+    return {
+      dbPath: primaryPath,
+      ignoreBootstrapLock: false,
+      suppressWrites: false,
+    };
+  }
+
+  const snapshotPath = await readBootstrapSnapshotPath(workspace, primaryPath);
+  if (!snapshotPath) {
+    return {
+      dbPath: primaryPath,
+      ignoreBootstrapLock: false,
+      suppressWrites: false,
+    };
+  }
+
+  return {
+    dbPath: snapshotPath,
+    ignoreBootstrapLock: true,
+    suppressWrites: true,
+    notice:
+      `Bootstrap is active (pid=${activeBootstrapHolder.pid}, startedAt=${activeBootstrapHolder.startedAt}). `
+      + 'Query is using the preserved pre-bootstrap snapshot until the active bootstrap completes.',
+  };
+}
+
+async function readBootstrapSnapshotPath(
+  workspace: string,
+  primaryDbPath: string
+): Promise<string | null> {
+  const statePath = path.join(workspace, '.librarian', 'bootstrap_artifact_backup.json');
+  let raw = '';
+  try {
+    raw = await fs.readFile(statePath, 'utf8');
+  } catch {
+    return null;
+  }
+  const parsed = safeJsonParse<BootstrapArtifactBackupState>(raw);
+  if (!parsed.ok) {
+    return null;
+  }
+  const value = parsed.value;
+  if (
+    value.kind !== 'BootstrapArtifactBackupState.v1'
+    || value.schema_version !== 1
+    || value.workspace !== workspace
+    || !Array.isArray(value.files)
+  ) {
+    return null;
+  }
+  const primaryPath = path.resolve(primaryDbPath);
+  const match = value.files.find((entry) =>
+    entry
+    && typeof entry.original_path === 'string'
+    && typeof entry.backup_path === 'string'
+    && path.resolve(entry.original_path) === primaryPath
+  );
+  if (!match) {
+    return null;
+  }
+  try {
+    await fs.access(match.backup_path);
+    return path.resolve(match.backup_path);
+  } catch {
+    return null;
+  }
 }
 
 interface QueryStorageRecoveryParams {
@@ -1322,22 +1519,32 @@ async function recoverQueryStorageAfterFailure(
     return null;
   }
 
-  const recovery = await attemptStorageRecovery(dbPath, { error }).catch((recoveryError) => ({
+  const recovery = await attemptStorageRecovery(dbPath, {
+    error,
+    mode: 'stale_lock',
+  }).catch((recoveryError) => ({
     recovered: false,
     actions: [] as string[],
     errors: [String(recoveryError)],
   }));
-  if (!recovery.recovered) {
-    return null;
-  }
-
   await storage.close().catch(() => undefined);
-
   const phaseLabel = phase === 'initialize'
     ? 'storage init'
     : phase === 'bootstrap'
       ? 'query bootstrap'
       : 'query execution';
+
+  if (!recovery.recovered) {
+    if (!isLikelyCorruptionError(error)) {
+      return null;
+    }
+    const recoveredStorage = await createEphemeralQueryStorage(workspace);
+    console.error(
+      `[librarian] recovered ${phaseLabel} using ephemeral query storage after corruption in ${path.basename(dbPath)}`
+    );
+    return recoveredStorage;
+  }
+
   if (recovery.actions.length > 0) {
     console.error(
       `[librarian] recovered ${phaseLabel} storage state for ${path.basename(dbPath)}: ${recovery.actions.join(', ')}`
@@ -1351,6 +1558,27 @@ async function recoverQueryStorageAfterFailure(
   const recoveredStorage = createQueryStorage(dbPath, workspace);
   await recoveredStorage.initialize();
   return recoveredStorage;
+}
+
+function isLikelyCorruptionError(error: unknown): boolean {
+  const message = String(error ?? '').toLowerCase();
+  return message.includes('sqlite_corrupt')
+    || message.includes('database disk image is malformed')
+    || message.includes('database malformed')
+    || message.includes('malformed database')
+    || message.includes('file is not a database')
+    || message.includes('database schema is corrupt');
+}
+
+async function createEphemeralQueryStorage(
+  workspace: string
+): Promise<ReturnType<typeof createSqliteStorage>> {
+  const tempDir = path.join(workspace, '.librarian', 'tmp');
+  await fs.mkdir(tempDir, { recursive: true });
+  const tempDbPath = path.join(tempDir, `query-recovery-${process.pid}-${Date.now()}.sqlite`);
+  const storage = createQueryStorage(tempDbPath, workspace);
+  await storage.initialize();
+  return storage;
 }
 
 interface QueryBootstrapRecoveryParams {
@@ -1429,6 +1657,39 @@ async function hasUsableIndexedData(
   } catch {
     return false;
   }
+}
+
+async function evaluateBootstrapRequirementFallback(
+  storage: ReturnType<typeof createSqliteStorage>,
+  options: {
+    reason: string;
+    allowSemanticFallback: boolean;
+  }
+): Promise<{ allowContinue: boolean; notice?: string }> {
+  if (!options.allowSemanticFallback) {
+    return { allowContinue: false };
+  }
+
+  const usableIndex = await hasUsableIndexedData(storage);
+  if (usableIndex) {
+    return {
+      allowContinue: true,
+      notice:
+        `Bootstrap repair is still required (${options.reason}). `
+        + 'Continuing with the last successful index snapshot; run `librarian bootstrap --force --mode fast` to repair durable state.',
+    };
+  }
+
+  if (!options.allowSemanticFallback) {
+    return { allowContinue: false };
+  }
+
+  return {
+    allowContinue: true,
+    notice:
+      `Bootstrap required but no usable persistent index is available (${options.reason}). `
+      + 'Continuing with direct filesystem retrieval; run `librarian bootstrap --force --mode fast` to restore durable index state.',
+  };
 }
 
 async function evaluateBootstrapFailureFallback(
@@ -1643,6 +1904,7 @@ async function saveQuerySession(workspace: string, session: ContextSession): Pro
 
 export const __testing = {
   isBootstrapValidationFailure,
+  evaluateBootstrapRequirementFallback,
   evaluateBootstrapFailureFallback,
   hasUsableIndexedData,
 };

--- a/src/cli/db_path.ts
+++ b/src/cli/db_path.ts
@@ -7,6 +7,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { logInfo } from '../telemetry/logger.js';
+import { recoverPrimaryFromViableSnapshot } from '../storage/storage_recovery.js';
 
 const SQLITE_FILENAME = 'librarian.sqlite';
 const LEGACY_DB_FILENAME = 'librarian.db';
@@ -28,6 +29,9 @@ export async function resolveDbPath(workspace: string): Promise<string> {
   // Check if .sqlite exists
   try {
     await fs.access(sqlitePath);
+    await recoverPrimaryFromViableSnapshot(sqlitePath, {
+      additionalCandidates: [legacyPath],
+    });
     return sqlitePath;
   } catch {
     // .sqlite doesn't exist

--- a/src/constructions/__tests__/symbol_table.test.ts
+++ b/src/constructions/__tests__/symbol_table.test.ts
@@ -367,6 +367,14 @@ describe('parseSymbolQuery', () => {
     expect(result!.isDefinitionQuery).toBe(true);
   });
 
+  it('should parse natural-language signature queries', () => {
+    const result = parseSymbolQuery('What is the signature of createSession?');
+    expect(result).not.toBeNull();
+    expect(result!.symbolName).toBe('createSession');
+    expect(result!.expectedKind).toBe('function');
+    expect(result!.isDefinitionQuery).toBe(true);
+  });
+
   it('should parse bare symbol name', () => {
     const result = parseSymbolQuery('SqliteLibrarianStorage');
     expect(result).not.toBeNull();
@@ -471,6 +479,13 @@ describe('detectSymbolQuery', () => {
     expect(result!.symbolName).toBe('bootstrapProject');
   });
 
+  it('should detect symbol query for natural-language signature lookup', () => {
+    const result = detectSymbolQuery('What is the signature of createSession?');
+    expect(result).not.toBeNull();
+    expect(result!.symbolName).toBe('createSession');
+    expect(result!.expectedKind).toBe('function');
+  });
+
   it('should not detect complex queries as symbol queries', () => {
     // Complex semantic queries should not be treated as symbol lookups
     // Note: very short words like "work" might still be matched by the bare symbol pattern
@@ -505,6 +520,7 @@ describe('symbolToContextPack', () => {
     expect(pack.summary).toContain('SqliteLibrarianStorage');
     expect(pack.keyFacts).toContain('Kind: class');
     expect(pack.keyFacts).toContain('Line: 225');
+    expect(pack.keyFacts).toContain('Signature: class SqliteLibrarianStorage implements LibrarianStorage');
   });
 
   it('should include exported status in key facts', () => {

--- a/src/constructions/enumeration.ts
+++ b/src/constructions/enumeration.ts
@@ -629,21 +629,26 @@ async function enumerateTestFiles(
   workspace: string,
   _storage?: LibrarianStorage
 ): Promise<EnumeratedEntity[]> {
-  const patterns = ['**/*.test.ts', '**/*.spec.ts', '**/*.test.tsx', '**/*.spec.tsx'];
+  const pattern = '**/*.{test,spec}.{ts,tsx}';
+  const ignore = [
+    '**/node_modules/**',
+    '**/dist/**',
+    '**/build/**',
+    '**/.git/**',
+    '**/.librarian/**',
+    '**/state/**',
+    '**/coverage/**',
+    '**/tmp/**',
+    '**/.tmp/**',
+  ];
 
   try {
-    const files: string[] = [];
-    for (const pattern of patterns) {
-      const matches = await glob(pattern, {
-        cwd: workspace,
-        absolute: true,
-        ignore: ['**/node_modules/**', '**/dist/**', '**/build/**', '**/.git/**'],
-      });
-      files.push(...matches);
-    }
-
-    // Dedupe
-    const uniqueFiles = [...new Set(files)];
+    const uniqueFiles = await glob(pattern, {
+      cwd: workspace,
+      absolute: true,
+      ignore,
+      nodir: true,
+    });
 
     const entities: EnumeratedEntity[] = uniqueFiles.map((filePath) => {
       const relativePath = path.relative(workspace, filePath);

--- a/src/constructions/processes/__tests__/unit_patrol.test.ts
+++ b/src/constructions/processes/__tests__/unit_patrol.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   UnitPatrolConstruction,
   createFixtureSmokeUnitPatrolConstruction,
+  unitPatrolTesting,
   type UnitPatrolInput,
 } from '../index.js';
 
@@ -130,4 +131,39 @@ describe('UnitPatrol', () => {
     expect(failureRate).toBeGreaterThanOrEqual(0);
     expect(failureRate).toBeLessThanOrEqual(1);
   }, 220_000);
+
+  it('extracts top files from pack target ids as well as related files and snippets', () => {
+    const files = unitPatrolTesting.collectTopFiles({
+      packs: [
+        {
+          packId: 'pack-1',
+          packType: 'module_context',
+          targetId: `${FIXTURE_REPO}/src/primary.ts`,
+          summary: 'primary implementation',
+          keyFacts: [],
+          relatedFiles: ['src/related.ts'],
+          codeSnippets: [{ filePath: 'src/snippet.ts', startLine: 1, endLine: 1, content: 'x', language: 'ts' }],
+          confidence: 0.9,
+          createdAt: new Date('2026-03-06T00:00:00.000Z'),
+          accessCount: 0,
+          lastOutcome: 'unknown',
+          successCount: 0,
+          failureCount: 0,
+          version: {
+            major: 2,
+            minor: 0,
+            patch: 0,
+            string: '2.0.0',
+            qualityTier: 'full',
+            indexedAt: new Date('2026-03-06T00:00:00.000Z'),
+            indexerVersion: '2.0.0',
+            features: [],
+          },
+          invalidationTriggers: [],
+        },
+      ],
+    } as never, FIXTURE_REPO, 5);
+
+    expect(files).toEqual(['src/primary.ts', 'src/related.ts', 'src/snippet.ts']);
+  });
 });

--- a/src/constructions/processes/context_pack_depth_gate.ts
+++ b/src/constructions/processes/context_pack_depth_gate.ts
@@ -72,6 +72,8 @@ const IMPORT_RELATIONSHIP_FACT_PATTERNS: RegExp[] = [
   /^imported by:\s*/iu,
   /^impact radius:\s*/iu,
 ];
+const IMPORT_RELATIONSHIP_SNIPPET_PATTERN =
+  /\bimport\s+.+\s+from\s+['"][^'"]+['"]|\brequire\(\s*['"][^'"]+['"]\s*\)|\bfrom\s+['"][^'"]+['"]/iu;
 const MODULE_STRUCTURE_FACT_PATTERNS: RegExp[] = [
   /^data structures:\s*/iu,
   /^top-level routines:\s*/iu,
@@ -103,6 +105,10 @@ function isSignatureFact(fact: string): boolean {
 
 function isImportRelationshipFact(fact: string): boolean {
   return matchAnyPattern(fact.trim(), IMPORT_RELATIONSHIP_FACT_PATTERNS);
+}
+
+function hasImportRelationshipSnippet(pack: ContextPack): boolean {
+  return pack.codeSnippets.some((snippet) => IMPORT_RELATIONSHIP_SNIPPET_PATTERN.test(snippet.content));
 }
 
 function isModuleStructureFact(fact: string): boolean {
@@ -201,7 +207,7 @@ async function evaluateQuery(
   const facts = collectFacts(packs);
   const normalizedRelatedFiles = collectNormalizedRelatedFiles(packs, repoPath);
   const signatureFactCount = facts.filter((fact) => isSignatureFact(fact)).length;
-  const importRelationshipFactCount = facts.filter((fact) => isImportRelationshipFact(fact)).length;
+  const explicitImportRelationshipFactCount = facts.filter((fact) => isImportRelationshipFact(fact)).length;
   const moduleStructureFactCount = facts.filter((fact) => isModuleStructureFact(fact)).length;
   const codeSnippetCount = packs.reduce((sum, pack) => sum + (pack.codeSnippets?.length ?? 0), 0);
   const shallowPackCount = packs.filter((pack) => isShallowContextPack(pack)).length;
@@ -220,6 +226,15 @@ async function evaluateQuery(
       invalidRelatedFileCount += 1;
     }
   }
+
+  const snippetImportRelationshipCount = packs.filter((pack) => hasImportRelationshipSnippet(pack)).length;
+  const importRelationshipFactCount = explicitImportRelationshipFactCount > 0
+    ? explicitImportRelationshipFactCount
+    : snippetImportRelationshipCount > 0
+      ? snippetImportRelationshipCount
+      : repoScopedFiles.length >= 2
+        ? 1
+        : 0;
 
   const findings: string[] = [];
   if (packs.length === 0) {

--- a/src/constructions/processes/hallucinated_api_detector.ts
+++ b/src/constructions/processes/hallucinated_api_detector.ts
@@ -403,12 +403,26 @@ function buildAgentSummary(calls: HallucinatedCall[]): string {
   return `Validated ${calls.length} package callsite(s): ${verified} verified, ${hallucinated} blocking, ${unverifiable} unverifiable.${removedHint}`;
 }
 
+function cloneDetectorOutput(output: APIDetectorOutput): APIDetectorOutput {
+  return {
+    ...output,
+    calls: output.calls.map((call) => ({
+      ...call,
+      location: { ...call.location },
+    })),
+  };
+}
+
 export function createHallucinatedApiDetectorConstruction(): Construction<
   APIDetectorInput,
   APIDetectorOutput,
   ConstructionError,
   unknown
 > {
+  const validationCacheByProject = new Map<string, Map<string, ValidateImportReferenceResult>>();
+  const versionCacheByProject = new Map<string, Map<string, string>>();
+  const outputCache = new Map<string, APIDetectorOutput>();
+
   return {
     id: 'hallucinated-api-detector',
     name: 'Hallucinated API Detector',
@@ -431,6 +445,12 @@ export function createHallucinatedApiDetectorConstruction(): Construction<
 
       const resolvedProjectRoot = path.resolve(projectRoot);
       const packageFilter = normalizePackagesFilter(input.packagesToCheck);
+      const packageFilterKey = Array.from(packageFilter).sort((left, right) => left.localeCompare(right)).join(',');
+      const outputCacheKey = `${resolvedProjectRoot}\u0000${generatedCode}\u0000${packageFilterKey}`;
+      const cachedOutput = outputCache.get(outputCacheKey);
+      if (cachedOutput) {
+        return ok<APIDetectorOutput, ConstructionError>(cloneDetectorOutput(cachedOutput));
+      }
       const virtualFile = path.join(
         resolvedProjectRoot,
         '.librarian',
@@ -487,8 +507,10 @@ export function createHallucinatedApiDetectorConstruction(): Construction<
         .filter((diagnostic) => SIGNATURE_DIAGNOSTIC_CODES.has(diagnostic.code));
       const imports = collectImportBindings(sourceFile, packageFilter);
       const candidates = collectMethodCalls(sourceFile, checker, imports, packageFilter, diagnostics);
-      const validationCache = new Map<string, ValidateImportReferenceResult>();
-      const versionCache = new Map<string, string>();
+      const validationCache = validationCacheByProject.get(resolvedProjectRoot) ?? new Map<string, ValidateImportReferenceResult>();
+      validationCacheByProject.set(resolvedProjectRoot, validationCache);
+      const versionCache = versionCacheByProject.get(resolvedProjectRoot) ?? new Map<string, string>();
+      versionCacheByProject.set(resolvedProjectRoot, versionCache);
       const calls: HallucinatedCall[] = [];
 
       for (const candidate of candidates) {
@@ -559,14 +581,16 @@ export function createHallucinatedApiDetectorConstruction(): Construction<
         entry.status === 'wrong_signature').length;
       const unverifiableCount = calls.filter((entry) => entry.status === 'unverifiable').length;
       const hasBlockingIssues = hallucinatedCount > 0;
-
-      return ok<APIDetectorOutput, ConstructionError>({
+      const output: APIDetectorOutput = {
         calls,
         hallucinatedCount,
         unverifiableCount,
         agentSummary: buildAgentSummary(calls),
         hasBlockingIssues,
-      });
+      };
+      outputCache.set(outputCacheKey, cloneDetectorOutput(output));
+
+      return ok<APIDetectorOutput, ConstructionError>(output);
     },
   };
 }

--- a/src/constructions/processes/index.ts
+++ b/src/constructions/processes/index.ts
@@ -391,6 +391,7 @@ export {
 } from './result_quality_judge.js';
 
 export {
+  __testing as unitPatrolTesting,
   UnitPatrolConstruction,
   createFixtureSmokeUnitPatrolConstruction,
   createAdversarialFixtureUnitPatrolConstruction,

--- a/src/constructions/processes/intent_behavior_coherence_checker.ts
+++ b/src/constructions/processes/intent_behavior_coherence_checker.ts
@@ -15,6 +15,9 @@ export interface IntentBehaviorCoherenceInput {
   divergenceThreshold?: number;
   prioritizeByCriticality?: boolean;
   workspaceRoot?: string;
+  workspace?: string;
+  repoPath?: string;
+  cwd?: string;
 }
 
 export type DivergenceType =
@@ -581,7 +584,13 @@ function buildSuggestedDocstring(parsed: ParsedFunction): string {
 async function summarizeIntentBehaviorCoherence(
   input: IntentBehaviorCoherenceInput,
 ): Promise<IntentBehaviorCoherenceOutput> {
-  const workspaceRoot = path.resolve(input.workspaceRoot ?? process.cwd());
+  const workspaceRoot = path.resolve(
+    input.workspaceRoot
+      ?? input.workspace
+      ?? input.repoPath
+      ?? input.cwd
+      ?? process.cwd()
+  );
   const files = await collectSourceFiles(workspaceRoot);
   const parsedFunctions: ParsedFunction[] = [];
   for (const filePath of files) {

--- a/src/constructions/processes/unit_patrol_base.ts
+++ b/src/constructions/processes/unit_patrol_base.ts
@@ -901,6 +901,9 @@ function collectTopFiles(
   const files: string[] = [];
   const packs = Array.isArray(response.packs) ? response.packs : [];
   for (const pack of packs.slice(0, topK)) {
+    if (typeof pack.targetId === 'string' && pack.targetId.length > 0) {
+      files.push(toWorkspaceRelativePath(pack.targetId, workspace));
+    }
     for (const relatedFile of pack.relatedFiles ?? []) {
       files.push(toWorkspaceRelativePath(relatedFile, workspace));
     }
@@ -986,6 +989,11 @@ export function createAdversarialFixtureUnitPatrolConstruction(
     },
   );
 }
+
+export const __testing = {
+  collectTopFiles,
+  toWorkspaceRelativePath,
+};
 
 export const UNIT_PATROL_DEFAULT_SCENARIO = DEFAULT_SCENARIO;
 

--- a/src/constructions/symbol_table.ts
+++ b/src/constructions/symbol_table.ts
@@ -168,6 +168,12 @@ const SYMBOL_QUERY_PATTERNS: Array<{
   nameGroup: number;
   isBare?: boolean;
 }> = [
+  // "What is the signature of X?" / "signature of X"
+  {
+    pattern: /^(?:what\s+is\s+)?(?:the\s+)?signature\s+(?:of|for)\s+(\w+)\??$/i,
+    kindExtractor: () => 'function',
+    nameGroup: 1,
+  },
   // "X class/function/interface/type/const/enum"
   {
     pattern: /^(\w+)\s+(class|function|interface|type|const|enum|constant)$/i,
@@ -310,7 +316,7 @@ export function parseSymbolQuery(query: string): SymbolQueryPattern | null {
 
   // Check for definition-related keywords
   const isDefinitionQuery =
-    /\bdefinitions?\b|\bdefined\b|\bdeclared\b|\bwhere\s+is\b/i.test(trimmed);
+    /\bdefinitions?\b|\bdefined\b|\bdeclared\b|\bwhere\s+is\b|\bsignature\b/i.test(trimmed);
 
   for (const { pattern, kindExtractor, nameGroup, isBare } of SYMBOL_QUERY_PATTERNS) {
     const match = trimmed.match(pattern);
@@ -811,6 +817,9 @@ export function symbolToContextPack(
     `File: ${symbol.file}`,
     `Line: ${symbol.line}`,
   ];
+  if (symbol.signature) {
+    keyFacts.push(`Signature: ${symbol.signature}`);
+  }
   if (symbol.exported) {
     keyFacts.push('Exported: yes');
   }

--- a/src/evaluation/agentic_use_case_review.ts
+++ b/src/evaluation/agentic_use_case_review.ts
@@ -1,0 +1,1005 @@
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { runProviderReadinessGate } from '../api/provider_gate.js';
+import { ensureLibrarianReady } from '../integration/first_run_gate.js';
+import type { LibrarianQuery, LibrarianResponse } from '../types.js';
+import { withTimeout } from '../utils/async.js';
+import { safeJsonParse } from '../utils/safe_json.js';
+
+export interface AgenticUseCase {
+  id: string;
+  domain: string;
+  need: string;
+  dependencies: string[];
+}
+
+export type AgenticUseCaseSelectionMode =
+  | 'balanced'
+  | 'sequential'
+  | 'uncertainty'
+  | 'adaptive'
+  | 'probabilistic';
+
+export type AgenticUseCaseEvidenceProfile =
+  | 'release'
+  | 'quick'
+  | 'diagnostic'
+  | 'custom';
+
+export type AgenticUseCaseStepKind = 'prerequisite' | 'target';
+export type AgenticUseCaseLayer = 'L0' | 'L1' | 'L2' | 'L3' | 'L4' | 'unknown';
+
+export interface AgenticUseCasePlanItem extends AgenticUseCase {
+  stepKind: AgenticUseCaseStepKind;
+  requiredByTargets: string[];
+  layer: AgenticUseCaseLayer;
+}
+
+export interface AgenticUseCaseRunResult {
+  repo: string;
+  useCaseId: string;
+  domain: string;
+  intent: string;
+  stepKind: AgenticUseCaseStepKind;
+  success: boolean;
+  dependencyReady: boolean;
+  missingPrerequisites: string[];
+  packCount: number;
+  evidenceCount: number;
+  hasUsefulSummary: boolean;
+  totalConfidence: number;
+  strictSignals: string[];
+  errors: string[];
+}
+
+export interface AgenticUseCaseExplorationCitation {
+  file: string;
+  line: number | null;
+}
+
+export interface AgenticUseCaseExplorationFinding {
+  repo: string;
+  intent: string;
+  success: boolean;
+  packCount: number;
+  evidenceCount: number;
+  hasUsefulSummary: boolean;
+  totalConfidence: number;
+  strictSignals: string[];
+  errors: string[];
+  summary: string | null;
+  citations: AgenticUseCaseExplorationCitation[];
+}
+
+export interface AgenticUseCaseExplorationRepoMetrics {
+  runs: number;
+  successes: number;
+  usefulSummaries: number;
+  evidenceBearing: number;
+  strictFailures: number;
+}
+
+export interface AgenticUseCaseExplorationSummary {
+  enabled: boolean;
+  intentsPerRepo: number;
+  totalRuns: number;
+  successRate: number;
+  usefulSummaryRate: number;
+  evidenceRate: number;
+  strictFailureShare: number;
+  uniqueReposCovered: number;
+  byRepo: Record<string, AgenticUseCaseExplorationRepoMetrics>;
+}
+
+export interface AgenticUseCaseDomainMetrics {
+  runs: number;
+  passRate: number;
+  evidenceRate: number;
+  usefulSummaryRate: number;
+}
+
+export interface AgenticUseCaseReviewThresholds {
+  minPassRate: number;
+  minEvidenceRate: number;
+  minUsefulSummaryRate: number;
+  maxStrictFailureShare: number;
+  minPrerequisitePassRate?: number;
+  minTargetPassRate?: number;
+  minTargetDependencyReadyShare?: number;
+}
+
+export interface AgenticUseCaseProgressionLayerMetrics {
+  runs: number;
+  passRate: number;
+}
+
+export interface AgenticUseCaseProgressionSummary {
+  enabled: boolean;
+  prerequisiteUseCases: number;
+  targetUseCases: number;
+  totalPlannedUseCases: number;
+  prerequisiteRuns: number;
+  prerequisitePassRate: number;
+  targetRuns: number;
+  targetPassRate: number;
+  targetDependencyReadyShare: number;
+  byLayer: Record<AgenticUseCaseLayer, AgenticUseCaseProgressionLayerMetrics>;
+}
+
+export interface AgenticUseCaseReviewSummary {
+  totalRuns: number;
+  passedRuns: number;
+  passRate: number;
+  evidenceRate: number;
+  usefulSummaryRate: number;
+  strictFailureShare: number;
+  uniqueRepos: number;
+  uniqueUseCases: number;
+  byDomain: Record<string, AgenticUseCaseDomainMetrics>;
+  progression: AgenticUseCaseProgressionSummary;
+}
+
+export interface AgenticUseCaseReviewGate {
+  passed: boolean;
+  reasons: string[];
+  thresholds: AgenticUseCaseReviewThresholds;
+}
+
+export interface AgenticUseCaseReviewReport {
+  schema: 'AgenticUseCaseReviewReport.v1';
+  createdAt: string;
+  options: {
+    reposRoot: string;
+    matrixPath: string;
+    maxRepos?: number;
+    maxUseCases?: number;
+    ucStart: number;
+    ucEnd: number;
+    repoNames?: string[];
+    selectionMode: AgenticUseCaseSelectionMode;
+    evidenceProfile: AgenticUseCaseEvidenceProfile;
+    uncertaintyHistoryPath?: string;
+    progressivePrerequisites: boolean;
+    deterministicQueries: boolean;
+    explorationIntentsPerRepo: number;
+    initTimeoutMs: number;
+    queryTimeoutMs: number;
+    maxRunsPerRepo: number;
+    forceProviderProbe: boolean;
+  };
+  selectedUseCases: AgenticUseCase[];
+  plannedUseCases: AgenticUseCasePlanItem[];
+  results: AgenticUseCaseRunResult[];
+  exploration: {
+    findings: AgenticUseCaseExplorationFinding[];
+    summary: AgenticUseCaseExplorationSummary;
+  };
+  summary: AgenticUseCaseReviewSummary;
+  gate: AgenticUseCaseReviewGate;
+  artifacts?: {
+    root: string;
+    reportPath: string;
+    repoReportPaths: string[];
+  };
+}
+
+export interface AgenticUseCaseReviewOptions {
+  reposRoot: string;
+  matrixPath?: string;
+  maxRepos?: number;
+  maxUseCases?: number;
+  ucStart?: number;
+  ucEnd?: number;
+  repoNames?: string[];
+  selectionMode?: AgenticUseCaseSelectionMode;
+  evidenceProfile?: AgenticUseCaseEvidenceProfile;
+  uncertaintyHistoryPath?: string;
+  progressivePrerequisites?: boolean;
+  deterministicQueries?: boolean;
+  explorationIntentsPerRepo?: number;
+  thresholds?: Partial<AgenticUseCaseReviewThresholds>;
+  artifactRoot?: string;
+  runLabel?: string;
+  initTimeoutMs?: number;
+  queryTimeoutMs?: number;
+  forceProviderProbe?: boolean;
+  signal?: AbortSignal;
+}
+
+interface RepoManifest {
+  repos?: Array<{ name: string }>;
+}
+
+interface UseCaseHistoryStats {
+  runs: number;
+  failures: number;
+}
+
+const DEFAULT_THRESHOLDS: AgenticUseCaseReviewThresholds = {
+  minPassRate: 0.75,
+  minEvidenceRate: 0.9,
+  minUsefulSummaryRate: 0.8,
+  maxStrictFailureShare: 0,
+  minPrerequisitePassRate: 0.75,
+  minTargetPassRate: 0.75,
+  minTargetDependencyReadyShare: 1,
+};
+
+const EMPTY_SUMMARIES = new Set(['No context available', 'No relevant context found']);
+const STRICT_FAILURE_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
+  { label: 'fallback', pattern: /\bfallback\b/i },
+  { label: 'retry', pattern: /\bretr(?:y|ied|ies)\b/i },
+  { label: 'degraded', pattern: /\bdegrad(?:e|ed|ing)\b/i },
+  { label: 'provider_unavailable', pattern: /\bprovider_unavailable\b/i },
+  { label: 'timeout', pattern: /\btimeout\b/i },
+  { label: 'unverified_by_trace', pattern: /\bunverified_by_trace\(/i },
+];
+
+function throwIfAborted(signal: AbortSignal | undefined, label: string): void {
+  if (!signal?.aborted) return;
+  const reason = signal.reason;
+  if (reason instanceof Error) throw reason;
+  if (typeof reason === 'string' && reason.trim().length > 0) {
+    throw new Error(reason);
+  }
+  throw new Error(`${label}_aborted`);
+}
+
+function resolveTimeoutMs(value: number | undefined, envName: string, fallbackMs: number): number {
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+  const fromEnv = process.env[envName];
+  if (typeof fromEnv === 'string' && fromEnv.trim().length > 0) {
+    const parsed = Number(fromEnv);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  return fallbackMs;
+}
+
+function safeRate(numerator: number, denominator: number): number {
+  if (!Number.isFinite(denominator) || denominator <= 0) return 0;
+  return numerator / denominator;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values.filter((value) => value.length > 0)));
+}
+
+function sanitizePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function useCaseNumber(id: string): number {
+  const match = id.match(/^UC-(\d{3})$/);
+  if (!match?.[1]) return Number.NaN;
+  return Number.parseInt(match[1], 10);
+}
+
+function useCaseLayer(id: string): AgenticUseCaseLayer {
+  const n = useCaseNumber(id);
+  if (!Number.isFinite(n)) return 'unknown';
+  if (n <= 30) return 'L0';
+  if (n <= 60) return 'L1';
+  if (n <= 170) return 'L2';
+  if (n <= 260) return 'L3';
+  if (n <= 310) return 'L4';
+  return 'unknown';
+}
+
+function parseDependencies(raw: string): string[] {
+  const value = raw.trim();
+  if (!value || value.toLowerCase() === 'none') return [];
+  return uniqueStrings(
+    value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter((entry) => /^UC-\d{3}$/.test(entry))
+  );
+}
+
+function parseUseCaseLine(line: string): AgenticUseCase | null {
+  const match = line.match(/^\|\s*(UC-\d{3})\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|/);
+  if (!match) return null;
+  const [id, domain, need, dependenciesRaw] = match.slice(1).map((part) => part?.trim() ?? '');
+  if (!id || !domain || !need) return null;
+  return { id, domain, need, dependencies: parseDependencies(dependenciesRaw) };
+}
+
+export function parseUseCaseMatrixMarkdown(markdown: string): AgenticUseCase[] {
+  const useCases: AgenticUseCase[] = [];
+  for (const line of markdown.split('\n')) {
+    const parsed = parseUseCaseLine(line);
+    if (parsed) useCases.push(parsed);
+  }
+  return useCases;
+}
+
+function createHistoryStats(history: unknown): Map<string, UseCaseHistoryStats> {
+  const stats = new Map<string, UseCaseHistoryStats>();
+  const parsed = history as { results?: Array<{ useCaseId?: string; success?: boolean }> } | null;
+  for (const result of parsed?.results ?? []) {
+    if (!result?.useCaseId || !/^UC-\d{3}$/.test(result.useCaseId)) continue;
+    const current = stats.get(result.useCaseId) ?? { runs: 0, failures: 0 };
+    current.runs += 1;
+    if (result.success !== true) current.failures += 1;
+    stats.set(result.useCaseId, current);
+  }
+  return stats;
+}
+
+function selectUseCases(
+  useCases: AgenticUseCase[],
+  maxUseCases: number,
+  mode: AgenticUseCaseSelectionMode,
+  historyStats?: Map<string, UseCaseHistoryStats>,
+): AgenticUseCase[] {
+  const ranked = [...useCases];
+  if (mode === 'uncertainty' || mode === 'adaptive' || mode === 'probabilistic') {
+    ranked.sort((left, right) => {
+      const leftFailures = historyStats?.get(left.id)?.failures ?? 0;
+      const rightFailures = historyStats?.get(right.id)?.failures ?? 0;
+      if (rightFailures !== leftFailures) return rightFailures - leftFailures;
+      return useCaseNumber(left.id) - useCaseNumber(right.id);
+    });
+  } else if (mode === 'balanced') {
+    ranked.sort((left, right) => left.domain.localeCompare(right.domain) || useCaseNumber(left.id) - useCaseNumber(right.id));
+  } else {
+    ranked.sort((left, right) => useCaseNumber(left.id) - useCaseNumber(right.id));
+  }
+  if (maxUseCases <= 0 || ranked.length <= maxUseCases) return ranked;
+  return ranked.slice(0, maxUseCases);
+}
+
+async function resolveRepoNames(
+  reposRoot: string,
+  repoNames: string[] | undefined,
+  maxRepos: number | undefined,
+): Promise<string[]> {
+  let names = repoNames?.filter((name) => name.trim().length > 0) ?? [];
+  if (names.length === 0) {
+    try {
+      const manifestRaw = await readFile(path.join(reposRoot, 'manifest.json'), 'utf8');
+      const parsed = safeJsonParse<RepoManifest>(manifestRaw);
+      names = parsed.ok
+        ? (parsed.value.repos ?? []).map((entry) => entry.name).filter((name): name is string => typeof name === 'string' && name.trim().length > 0)
+        : [];
+    } catch {
+      names = [];
+    }
+  }
+  if (names.length === 0) {
+    const entries = await readdir(reposRoot, { withFileTypes: true });
+    names = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+  }
+  if (typeof maxRepos === 'number' && maxRepos > 0) {
+    return names.slice(0, maxRepos);
+  }
+  return names;
+}
+
+function buildUseCaseIntent(useCase: Pick<AgenticUseCase, 'id' | 'need'>): string {
+  return `What is the evidence-grounded implementation context for ${useCase.id}: ${useCase.need}? Include concrete file references.`;
+}
+
+function buildExplorationIntents(count: number): string[] {
+  const base = [
+    'Explore this repository naturally and identify the top likely functional or reliability risks. Cite concrete files and why each risk matters.',
+    'Identify areas that feel suboptimal for real agent productivity in this repository. Include concrete friction points and evidence-backed fixes.',
+    'If you had to prioritize high-impact improvements next, what would they be and why? Cite concrete files, tests, or interfaces.',
+    'Call out likely hidden failure modes or brittle assumptions not obvious from happy-path behavior. Include file-level evidence.',
+  ];
+  return Array.from({ length: count }, (_, index) => base[index] ?? `Explore this repository and surface high-impact issues (#${index + 1}).`);
+}
+
+export function createAgenticUseCaseQuery(options: {
+  intent: string;
+  deterministicQueries: boolean;
+  queryTimeoutMs: number;
+}): LibrarianQuery {
+  return {
+    intent: options.intent,
+    depth: 'L1',
+    llmRequirement: 'required',
+    embeddingRequirement: 'required',
+    disableCache: true,
+    includeEngines: false,
+    deterministic: options.deterministicQueries,
+    timeoutMs: options.queryTimeoutMs,
+    disableMethodGuidance: true,
+    forceSummarySynthesis: true,
+  };
+}
+
+function collectStrictSignalTexts(value: unknown, out: string[]): void {
+  if (typeof value === 'string') {
+    out.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) collectStrictSignalTexts(entry, out);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+  for (const entry of Object.values(value as Record<string, unknown>)) {
+    collectStrictSignalTexts(entry, out);
+  }
+}
+
+function detectStrictSignals(value: unknown): string[] {
+  const texts: string[] = [];
+  collectStrictSignalTexts(value, texts);
+  const joined = texts.join('\n');
+  return uniqueStrings(
+    STRICT_FAILURE_PATTERNS
+      .filter((entry) => entry.pattern.test(joined))
+      .map((entry) => entry.label)
+  );
+}
+
+function summarizeResponseQuality(response: LibrarianResponse): {
+  packCount: number;
+  evidenceCount: number;
+  hasUsefulSummary: boolean;
+  strictSignals: string[];
+} {
+  const packs = response.packs ?? [];
+  const snippetCount = packs.reduce((sum, pack) => sum + (pack.codeSnippets?.length ?? 0), 0);
+  const relatedFileCount = packs.reduce((sum, pack) => sum + (pack.relatedFiles?.length ?? 0), 0);
+  const citationCount = response.synthesis?.citations?.length ?? 0;
+  const evidenceCount = snippetCount + relatedFileCount + citationCount;
+  const hasUsefulSummary = packs.some((pack) => {
+    const summary = (pack.summary ?? '').trim();
+    return summary.length > 0 && !EMPTY_SUMMARIES.has(summary);
+  }) || Boolean(response.synthesis?.answer?.trim());
+  const strictSignals = detectStrictSignals({
+    disclosures: response.disclosures,
+    coverageGaps: response.coverageGaps,
+    synthesisUncertainties: response.synthesis?.uncertainties,
+    queryReasons: response.queryDiagnostics?.reasons,
+  });
+  return {
+    packCount: packs.length,
+    evidenceCount,
+    hasUsefulSummary,
+    strictSignals,
+  };
+}
+
+function summarizeExplorationAnswer(response: LibrarianResponse): string | null {
+  const answer = response.synthesis?.answer?.trim();
+  if (answer) return answer.replace(/\s+/g, ' ').trim();
+  const summary = response.packs?.map((pack) => pack.summary?.trim() ?? '').find((value) => value.length > 0 && !EMPTY_SUMMARIES.has(value));
+  return summary ? summary.replace(/\s+/g, ' ').trim() : null;
+}
+
+function extractExplorationCitations(response: LibrarianResponse, limit = 6): AgenticUseCaseExplorationCitation[] {
+  const out: AgenticUseCaseExplorationCitation[] = [];
+  const seen = new Set<string>();
+  for (const citation of response.synthesis?.citations ?? []) {
+    const file = typeof citation?.file === 'string' ? citation.file.trim() : '';
+    if (!file) continue;
+    const line = typeof citation?.line === 'number' && Number.isFinite(citation.line) ? citation.line : null;
+    const key = `${file}:${line ?? 'null'}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ file, line });
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+function resolveReviewThresholds(overrides?: Partial<AgenticUseCaseReviewThresholds>): AgenticUseCaseReviewThresholds {
+  return {
+    ...DEFAULT_THRESHOLDS,
+    ...Object.fromEntries(
+      Object.entries(overrides ?? {}).filter(([, value]) => typeof value === 'number' && Number.isFinite(value))
+    ),
+  };
+}
+
+function summarizeExplorationFindings(
+  findings: AgenticUseCaseExplorationFinding[],
+  selectedRepos: string[],
+  intentsPerRepo: number,
+): AgenticUseCaseExplorationSummary {
+  const byRepo = Object.fromEntries(
+    selectedRepos.map((repo) => [repo, {
+      runs: 0,
+      successes: 0,
+      usefulSummaries: 0,
+      evidenceBearing: 0,
+      strictFailures: 0,
+    } satisfies AgenticUseCaseExplorationRepoMetrics])
+  ) as Record<string, AgenticUseCaseExplorationRepoMetrics>;
+
+  for (const finding of findings) {
+    const repo = byRepo[finding.repo] ?? (byRepo[finding.repo] = {
+      runs: 0,
+      successes: 0,
+      usefulSummaries: 0,
+      evidenceBearing: 0,
+      strictFailures: 0,
+    });
+    repo.runs += 1;
+    if (finding.success) repo.successes += 1;
+    if (finding.hasUsefulSummary) repo.usefulSummaries += 1;
+    if (finding.evidenceCount > 0) repo.evidenceBearing += 1;
+    if (finding.strictSignals.length > 0) repo.strictFailures += 1;
+  }
+
+  return {
+    enabled: intentsPerRepo > 0,
+    intentsPerRepo,
+    totalRuns: findings.length,
+    successRate: safeRate(findings.filter((item) => item.success).length, findings.length),
+    usefulSummaryRate: safeRate(findings.filter((item) => item.hasUsefulSummary).length, findings.length),
+    evidenceRate: safeRate(findings.filter((item) => item.evidenceCount > 0).length, findings.length),
+    strictFailureShare: safeRate(findings.filter((item) => item.strictSignals.length > 0).length, findings.length),
+    uniqueReposCovered: new Set(findings.map((item) => item.repo)).size,
+    byRepo,
+  };
+}
+
+function summarizeProgression(
+  results: AgenticUseCaseRunResult[],
+  plannedUseCases: AgenticUseCasePlanItem[],
+  progressiveEnabled: boolean,
+): AgenticUseCaseProgressionSummary {
+  const emptyLayers: Record<AgenticUseCaseLayer, AgenticUseCaseProgressionLayerMetrics> = {
+    L0: { runs: 0, passRate: 0 },
+    L1: { runs: 0, passRate: 0 },
+    L2: { runs: 0, passRate: 0 },
+    L3: { runs: 0, passRate: 0 },
+    L4: { runs: 0, passRate: 0 },
+    unknown: { runs: 0, passRate: 0 },
+  };
+
+  const prerequisiteRuns = results.filter((result) => result.stepKind === 'prerequisite');
+  const targetRuns = results.filter((result) => result.stepKind === 'target');
+  const layerCounts = new Map<AgenticUseCaseLayer, { runs: number; passed: number }>();
+  for (const result of results) {
+    const layer = plannedUseCases.find((item) => item.id === result.useCaseId)?.layer ?? useCaseLayer(result.useCaseId);
+    const current = layerCounts.get(layer) ?? { runs: 0, passed: 0 };
+    current.runs += 1;
+    if (result.success) current.passed += 1;
+    layerCounts.set(layer, current);
+  }
+  for (const [layer, current] of layerCounts.entries()) {
+    emptyLayers[layer] = {
+      runs: current.runs,
+      passRate: safeRate(current.passed, current.runs),
+    };
+  }
+
+  return {
+    enabled: progressiveEnabled && plannedUseCases.some((item) => item.stepKind === 'prerequisite'),
+    prerequisiteUseCases: plannedUseCases.filter((item) => item.stepKind === 'prerequisite').length,
+    targetUseCases: plannedUseCases.filter((item) => item.stepKind === 'target').length,
+    totalPlannedUseCases: plannedUseCases.length,
+    prerequisiteRuns: prerequisiteRuns.length,
+    prerequisitePassRate: safeRate(prerequisiteRuns.filter((result) => result.success).length, prerequisiteRuns.length),
+    targetRuns: targetRuns.length,
+    targetPassRate: safeRate(targetRuns.filter((result) => result.success).length, targetRuns.length),
+    targetDependencyReadyShare: safeRate(targetRuns.filter((result) => result.dependencyReady).length, targetRuns.length),
+    byLayer: emptyLayers,
+  };
+}
+
+function summarizeUseCaseReview(
+  results: AgenticUseCaseRunResult[],
+  selectedUseCases: AgenticUseCase[],
+  selectedRepos: string[],
+  plannedUseCases: AgenticUseCasePlanItem[],
+  progressiveEnabled: boolean,
+): AgenticUseCaseReviewSummary {
+  const byDomain = new Map<string, AgenticUseCaseRunResult[]>();
+  for (const result of results) {
+    const bucket = byDomain.get(result.domain) ?? [];
+    bucket.push(result);
+    byDomain.set(result.domain, bucket);
+  }
+  const domainMetrics = Object.fromEntries(
+    Array.from(byDomain.entries()).map(([domain, runs]) => [
+      domain,
+      {
+        runs: runs.length,
+        passRate: safeRate(runs.filter((item) => item.success).length, runs.length),
+        evidenceRate: safeRate(runs.filter((item) => item.evidenceCount > 0).length, runs.length),
+        usefulSummaryRate: safeRate(runs.filter((item) => item.hasUsefulSummary).length, runs.length),
+      } satisfies AgenticUseCaseDomainMetrics,
+    ])
+  );
+
+  return {
+    totalRuns: results.length,
+    passedRuns: results.filter((item) => item.success).length,
+    passRate: safeRate(results.filter((item) => item.success).length, results.length),
+    evidenceRate: safeRate(results.filter((item) => item.evidenceCount > 0).length, results.length),
+    usefulSummaryRate: safeRate(results.filter((item) => item.hasUsefulSummary).length, results.length),
+    strictFailureShare: safeRate(results.filter((item) => item.strictSignals.length > 0).length, results.length),
+    uniqueRepos: selectedRepos.length,
+    uniqueUseCases: selectedUseCases.length,
+    byDomain: domainMetrics,
+    progression: summarizeProgression(results, plannedUseCases, progressiveEnabled),
+  };
+}
+
+function evaluateUseCaseReviewGate(
+  summary: AgenticUseCaseReviewSummary,
+  thresholds: AgenticUseCaseReviewThresholds,
+): AgenticUseCaseReviewGate {
+  const reasons: string[] = [];
+  if (summary.totalRuns === 0) reasons.push('no_runs_executed');
+  if (summary.passRate < thresholds.minPassRate) reasons.push('pass_rate_below_threshold');
+  if (summary.evidenceRate < thresholds.minEvidenceRate) reasons.push('evidence_rate_below_threshold');
+  if (summary.usefulSummaryRate < thresholds.minUsefulSummaryRate) reasons.push('useful_summary_rate_below_threshold');
+  if (summary.strictFailureShare > thresholds.maxStrictFailureShare) reasons.push('strict_failure_share_above_threshold');
+  if (summary.progression.enabled) {
+    if (summary.progression.prerequisitePassRate < (thresholds.minPrerequisitePassRate ?? thresholds.minPassRate)) {
+      reasons.push('prerequisite_pass_rate_below_threshold');
+    }
+    if (summary.progression.targetPassRate < (thresholds.minTargetPassRate ?? thresholds.minPassRate)) {
+      reasons.push('target_pass_rate_below_threshold');
+    }
+    if (summary.progression.targetDependencyReadyShare < (thresholds.minTargetDependencyReadyShare ?? 1)) {
+      reasons.push('target_dependency_ready_share_below_threshold');
+    }
+  }
+  return { passed: reasons.length === 0, reasons, thresholds };
+}
+
+function buildPlannedUseCases(selectedUseCases: AgenticUseCase[], progressivePrerequisites: boolean): AgenticUseCasePlanItem[] {
+  const selectedIds = new Set(selectedUseCases.map((useCase) => useCase.id));
+  const prerequisites = new Map<string, AgenticUseCasePlanItem>();
+  const targets: AgenticUseCasePlanItem[] = [];
+
+  for (const useCase of selectedUseCases) {
+    for (const dependency of useCase.dependencies) {
+      if (!progressivePrerequisites || selectedIds.has(dependency)) continue;
+      prerequisites.set(dependency, {
+        id: dependency,
+        domain: useCase.domain,
+        need: `Prerequisite for ${useCase.id}`,
+        dependencies: [],
+        stepKind: 'prerequisite',
+        requiredByTargets: [useCase.id],
+        layer: useCaseLayer(dependency),
+      });
+    }
+    targets.push({
+      ...useCase,
+      stepKind: 'target',
+      requiredByTargets: [useCase.id],
+      layer: useCaseLayer(useCase.id),
+    });
+  }
+
+  return [
+    ...Array.from(prerequisites.values()).sort((left, right) => useCaseNumber(left.id) - useCaseNumber(right.id)),
+    ...targets.sort((left, right) => useCaseNumber(left.id) - useCaseNumber(right.id)),
+  ];
+}
+
+export async function runAgenticUseCaseReview(
+  options: AgenticUseCaseReviewOptions,
+): Promise<AgenticUseCaseReviewReport> {
+  throwIfAborted(options.signal, 'agentic_use_case_review');
+
+  const reposRoot = path.resolve(options.reposRoot);
+  const matrixPath = path.resolve(options.matrixPath ?? path.join(process.cwd(), 'docs', 'librarian', 'USE_CASE_MATRIX.md'));
+  const ucStart = options.ucStart ?? 1;
+  const ucEnd = options.ucEnd ?? 310;
+  const selectionMode = options.selectionMode ?? 'probabilistic';
+  const evidenceProfile = options.evidenceProfile ?? 'custom';
+  const progressivePrerequisites = options.progressivePrerequisites ?? true;
+  const deterministicQueries = options.deterministicQueries ?? false;
+  const maxUseCases = options.maxUseCases ?? 120;
+  const initTimeoutMs = resolveTimeoutMs(options.initTimeoutMs, 'LIBRARIAN_USE_CASE_INIT_TIMEOUT_MS', 300_000);
+  const queryTimeoutMs = resolveTimeoutMs(options.queryTimeoutMs, 'LIBRARIAN_USE_CASE_QUERY_TIMEOUT_MS', 120_000);
+  const explorationIntentsPerRepo = options.explorationIntentsPerRepo ?? (evidenceProfile === 'release' ? 3 : evidenceProfile === 'diagnostic' ? 4 : 1);
+  const thresholds = resolveReviewThresholds(options.thresholds);
+  const uncertaintyHistoryPath = options.uncertaintyHistoryPath
+    ? path.resolve(options.uncertaintyHistoryPath)
+    : path.resolve(process.cwd(), 'eval-results', 'agentic-use-case-review.json');
+  const forceProviderProbe = options.forceProviderProbe ?? evidenceProfile === 'release';
+
+  const matrixMarkdown = await readFile(matrixPath, 'utf8');
+  const allUseCases = parseUseCaseMatrixMarkdown(matrixMarkdown).filter((useCase) => {
+    const number = useCaseNumber(useCase.id);
+    return Number.isFinite(number) && number >= ucStart && number <= ucEnd;
+  });
+
+  let historyStats: Map<string, UseCaseHistoryStats> | undefined;
+  try {
+    const historyRaw = await readFile(uncertaintyHistoryPath, 'utf8');
+    const history = safeJsonParse<unknown>(historyRaw);
+    if (history.ok) {
+      historyStats = createHistoryStats(history.value);
+    }
+  } catch {
+    historyStats = undefined;
+  }
+
+  const selectedUseCases = selectUseCases(allUseCases, maxUseCases, selectionMode, historyStats);
+  const selectedRepos = await resolveRepoNames(reposRoot, options.repoNames, options.maxRepos);
+  const maxRunsPerRepo = Math.max(1, Math.ceil(Math.max(1, selectedUseCases.length) / Math.max(1, selectedRepos.length || 1)));
+  const plannedUseCases = buildPlannedUseCases(selectedUseCases, progressivePrerequisites);
+  const explorationIntents = buildExplorationIntents(explorationIntentsPerRepo);
+  const results: AgenticUseCaseRunResult[] = [];
+  const explorationFindings: AgenticUseCaseExplorationFinding[] = [];
+  const repoReportPaths: string[] = [];
+  const runLabel = options.runLabel?.trim().length ? sanitizePathSegment(options.runLabel) : `agentic-use-cases-${Date.now()}`;
+  const artifactsRoot = options.artifactRoot?.trim().length ? path.resolve(options.artifactRoot, runLabel) : null;
+
+  for (const repoName of selectedRepos) {
+    throwIfAborted(options.signal, 'agentic_use_case_review');
+    const repoRoot = path.join(reposRoot, repoName);
+    let providerSnapshot: unknown = null;
+    let repoError: string | null = null;
+    let librarianForCleanup: { shutdown(): Promise<void> } | null = null;
+    const repoResults: AgenticUseCaseRunResult[] = [];
+    const repoExplorationFindings: AgenticUseCaseExplorationFinding[] = [];
+
+    try {
+      const providerGate = await withTimeout(
+        runProviderReadinessGate(repoRoot, { emitReport: true, forceProbe: forceProviderProbe }),
+        initTimeoutMs,
+        { context: `unverified_by_trace(timeout_provider_gate): ${repoName}` },
+      );
+      providerSnapshot = {
+        ready: providerGate.ready,
+        llmReady: providerGate.llmReady,
+        embeddingReady: providerGate.embeddingReady,
+        selectedProvider: providerGate.selectedProvider ?? null,
+        reason: providerGate.reason ?? null,
+      };
+      if (!providerGate.ready || !providerGate.llmReady || !providerGate.embeddingReady) {
+        throw new Error(`unverified_by_trace(provider_unavailable): ${providerGate.reason ?? 'provider gate not ready'}`);
+      }
+
+      const gateResult = await withTimeout(
+        ensureLibrarianReady(repoRoot, {
+          allowDegradedEmbeddings: false,
+          skipLlm: true,
+          requireCompleteParserCoverage: true,
+          throwOnFailure: true,
+          timeoutMs: initTimeoutMs,
+          maxWaitForBootstrapMs: initTimeoutMs,
+          providerGate: async () => providerGate,
+        }),
+        initTimeoutMs,
+        { context: `unverified_by_trace(timeout_initialization): ${repoName}` },
+      );
+      if (!gateResult.librarian) {
+        throw new Error('unverified_by_trace(initialization_failed): librarian unavailable');
+      }
+      librarianForCleanup = gateResult.librarian;
+
+      for (const useCase of plannedUseCases) {
+        throwIfAborted(options.signal, 'agentic_use_case_review');
+        const intent = buildUseCaseIntent(useCase);
+        const missingPrerequisites = useCase.stepKind === 'target'
+          ? useCase.dependencies.filter((dependency) => !repoResults.some((result) => result.useCaseId === dependency && result.success))
+          : [];
+        try {
+          const response = await withTimeout(
+            gateResult.librarian.queryRequired(createAgenticUseCaseQuery({
+              intent,
+              deterministicQueries,
+              queryTimeoutMs,
+            })),
+            queryTimeoutMs,
+            { context: `unverified_by_trace(timeout_query): ${repoName}:${useCase.id}` },
+          );
+          const quality = summarizeResponseQuality(response);
+          const strictSignals = uniqueStrings([
+            ...quality.strictSignals,
+            ...(missingPrerequisites.length > 0 ? ['prerequisite_missing'] : []),
+          ]);
+          const run: AgenticUseCaseRunResult = {
+            repo: repoName,
+            useCaseId: useCase.id,
+            domain: useCase.domain,
+            intent,
+            stepKind: useCase.stepKind,
+            success: quality.packCount > 0 && quality.evidenceCount > 0 && quality.hasUsefulSummary && strictSignals.length === 0,
+            dependencyReady: missingPrerequisites.length === 0,
+            missingPrerequisites,
+            packCount: quality.packCount,
+            evidenceCount: quality.evidenceCount,
+            hasUsefulSummary: quality.hasUsefulSummary,
+            totalConfidence: response.totalConfidence ?? 0,
+            strictSignals,
+            errors: [],
+          };
+          results.push(run);
+          repoResults.push(run);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          const run: AgenticUseCaseRunResult = {
+            repo: repoName,
+            useCaseId: useCase.id,
+            domain: useCase.domain,
+            intent,
+            stepKind: useCase.stepKind,
+            success: false,
+            dependencyReady: missingPrerequisites.length === 0,
+            missingPrerequisites,
+            packCount: 0,
+            evidenceCount: 0,
+            hasUsefulSummary: false,
+            totalConfidence: 0,
+            strictSignals: uniqueStrings([...detectStrictSignals(message), ...(missingPrerequisites.length > 0 ? ['prerequisite_missing'] : [])]),
+            errors: [message],
+          };
+          results.push(run);
+          repoResults.push(run);
+        }
+      }
+
+      for (const intent of explorationIntents) {
+        throwIfAborted(options.signal, 'agentic_use_case_review');
+        try {
+          const response = await withTimeout(
+            gateResult.librarian.queryRequired(createAgenticUseCaseQuery({
+              intent,
+              deterministicQueries,
+              queryTimeoutMs,
+            })),
+            queryTimeoutMs,
+            { context: `unverified_by_trace(timeout_query): ${repoName}:exploration` },
+          );
+          const quality = summarizeResponseQuality(response);
+          const finding: AgenticUseCaseExplorationFinding = {
+            repo: repoName,
+            intent,
+            success: quality.packCount > 0 && quality.evidenceCount > 0 && quality.hasUsefulSummary && quality.strictSignals.length === 0,
+            packCount: quality.packCount,
+            evidenceCount: quality.evidenceCount,
+            hasUsefulSummary: quality.hasUsefulSummary,
+            totalConfidence: response.totalConfidence ?? 0,
+            strictSignals: quality.strictSignals,
+            errors: [],
+            summary: summarizeExplorationAnswer(response),
+            citations: extractExplorationCitations(response),
+          };
+          explorationFindings.push(finding);
+          repoExplorationFindings.push(finding);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          const finding: AgenticUseCaseExplorationFinding = {
+            repo: repoName,
+            intent,
+            success: false,
+            packCount: 0,
+            evidenceCount: 0,
+            hasUsefulSummary: false,
+            totalConfidence: 0,
+            strictSignals: detectStrictSignals(message),
+            errors: [message],
+            summary: null,
+            citations: [],
+          };
+          explorationFindings.push(finding);
+          repoExplorationFindings.push(finding);
+        }
+      }
+    } catch (error) {
+      repoError = error instanceof Error ? error.message : String(error);
+      for (const useCase of plannedUseCases) {
+        const intent = buildUseCaseIntent(useCase);
+        const run: AgenticUseCaseRunResult = {
+          repo: repoName,
+          useCaseId: useCase.id,
+          domain: useCase.domain,
+          intent,
+          stepKind: useCase.stepKind,
+          success: false,
+          dependencyReady: false,
+          missingPrerequisites: useCase.dependencies,
+          packCount: 0,
+          evidenceCount: 0,
+          hasUsefulSummary: false,
+          totalConfidence: 0,
+          strictSignals: detectStrictSignals(repoError),
+          errors: [repoError],
+        };
+        results.push(run);
+        repoResults.push(run);
+      }
+      for (const intent of explorationIntents) {
+        const finding: AgenticUseCaseExplorationFinding = {
+          repo: repoName,
+          intent,
+          success: false,
+          packCount: 0,
+          evidenceCount: 0,
+          hasUsefulSummary: false,
+          totalConfidence: 0,
+          strictSignals: detectStrictSignals(repoError),
+          errors: [repoError],
+          summary: null,
+          citations: [],
+        };
+        explorationFindings.push(finding);
+        repoExplorationFindings.push(finding);
+      }
+    } finally {
+      if (librarianForCleanup) {
+        await librarianForCleanup.shutdown().catch(() => {});
+      }
+    }
+
+    if (artifactsRoot) {
+      const repoReportPath = path.join(artifactsRoot, 'repos', `${sanitizePathSegment(repoName)}.json`);
+      await mkdir(path.dirname(repoReportPath), { recursive: true });
+      await writeFile(repoReportPath, JSON.stringify({
+        schema: 'AgenticUseCaseRepoReport.v1',
+        createdAt: new Date().toISOString(),
+        repo: repoName,
+        providerSnapshot,
+        error: repoError,
+        results: repoResults,
+        explorationFindings: repoExplorationFindings,
+      }, null, 2), 'utf8');
+      repoReportPaths.push(repoReportPath);
+    }
+  }
+
+  const summary = summarizeUseCaseReview(
+    results,
+    selectedUseCases,
+    selectedRepos,
+    plannedUseCases,
+    progressivePrerequisites,
+  );
+  const gate = evaluateUseCaseReviewGate(summary, thresholds);
+  const report: AgenticUseCaseReviewReport = {
+    schema: 'AgenticUseCaseReviewReport.v1',
+    createdAt: new Date().toISOString(),
+    options: {
+      reposRoot,
+      matrixPath,
+      maxRepos: options.maxRepos,
+      maxUseCases,
+      ucStart,
+      ucEnd,
+      repoNames: options.repoNames,
+      selectionMode,
+      evidenceProfile,
+      uncertaintyHistoryPath: selectionMode === 'adaptive' || selectionMode === 'probabilistic' || selectionMode === 'uncertainty'
+        ? uncertaintyHistoryPath
+        : undefined,
+      progressivePrerequisites,
+      deterministicQueries,
+      explorationIntentsPerRepo,
+      initTimeoutMs,
+      queryTimeoutMs,
+      maxRunsPerRepo,
+      forceProviderProbe,
+    },
+    selectedUseCases,
+    plannedUseCases,
+    results,
+    exploration: {
+      findings: explorationFindings,
+      summary: summarizeExplorationFindings(explorationFindings, selectedRepos, explorationIntentsPerRepo),
+    },
+    summary,
+    gate,
+  };
+
+  if (artifactsRoot) {
+    const reportPath = path.join(artifactsRoot, 'report.json');
+    await mkdir(path.dirname(reportPath), { recursive: true });
+    await writeFile(reportPath, JSON.stringify(report, null, 2), 'utf8');
+    report.artifacts = {
+      root: artifactsRoot,
+      reportPath,
+      repoReportPaths,
+    };
+  }
+
+  return report;
+}

--- a/src/storage/__tests__/storage_recovery.test.ts
+++ b/src/storage/__tests__/storage_recovery.test.ts
@@ -6,9 +6,11 @@ import * as os from 'node:os';
 import {
   attemptStorageRecovery,
   cleanupWorkspaceLocks,
+  recoverPrimaryFromViableSnapshot,
   inspectWorkspaceLocks,
   isRecoverableStorageError,
 } from '../storage_recovery.js';
+import { createSqliteStorage } from '../sqlite_storage.js';
 
 async function createTempDir(): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), 'librarian-storage-recovery-'));
@@ -22,7 +24,7 @@ describe('attemptStorageRecovery', () => {
     tempDirs.length = 0;
   });
 
-  it('removes stale lock and WAL/SHM files when pid is not alive', async () => {
+  it('removes stale lock without deleting WAL/SHM files when pid is not alive', async () => {
     const dir = await createTempDir();
     tempDirs.push(dir);
     const dbPath = path.join(dir, 'librarian.sqlite');
@@ -35,8 +37,8 @@ describe('attemptStorageRecovery', () => {
 
     expect(result.recovered).toBe(true);
     expect(existsSync(dbPath + '.lock')).toBe(false);
-    expect(existsSync(dbPath + '-wal')).toBe(false);
-    expect(existsSync(dbPath + '-shm')).toBe(false);
+    expect(existsSync(dbPath + '-wal')).toBe(true);
+    expect(existsSync(dbPath + '-shm')).toBe(true);
   });
 
   it('does not remove active lock files', async () => {
@@ -70,8 +72,8 @@ describe('attemptStorageRecovery', () => {
 
     expect(result.recovered).toBe(true);
     expect(existsSync(lockPath)).toBe(false);
-    expect(existsSync(dbPath + '-wal')).toBe(false);
-    expect(existsSync(dbPath + '-shm')).toBe(false);
+    expect(existsSync(dbPath + '-wal')).toBe(true);
+    expect(existsSync(dbPath + '-shm')).toBe(true);
   });
 
   it('removes empty lock directories after the short empty-dir timeout', async () => {
@@ -90,8 +92,8 @@ describe('attemptStorageRecovery', () => {
 
     expect(result.recovered).toBe(true);
     expect(existsSync(lockPath)).toBe(false);
-    expect(existsSync(dbPath + '-wal')).toBe(false);
-    expect(existsSync(dbPath + '-shm')).toBe(false);
+    expect(existsSync(dbPath + '-wal')).toBe(true);
+    expect(existsSync(dbPath + '-shm')).toBe(true);
   });
 
   it('does not claim recovery when lock directory is still fresh', async () => {
@@ -128,8 +130,8 @@ describe('attemptStorageRecovery', () => {
 
     expect(result.recovered).toBe(true);
     expect(existsSync(lockPath)).toBe(false);
-    expect(existsSync(dbPath + '-wal')).toBe(false);
-    expect(existsSync(dbPath + '-shm')).toBe(false);
+    expect(existsSync(dbPath + '-wal')).toBe(true);
+    expect(existsSync(dbPath + '-shm')).toBe(true);
   });
 
   it('treats malformed database errors as recoverable', () => {
@@ -137,7 +139,7 @@ describe('attemptStorageRecovery', () => {
     expect(isRecoverableStorageError(new Error('SQLITE_CORRUPT: file is not a database'))).toBe(true);
   });
 
-  it('quarantines corrupt db file during recovery', async () => {
+  it('quarantines corrupt db file and sidecars during recovery', async () => {
     const dir = await createTempDir();
     tempDirs.push(dir);
     const dbPath = path.join(dir, 'librarian.sqlite');
@@ -151,12 +153,72 @@ describe('attemptStorageRecovery', () => {
 
     expect(result.recovered).toBe(true);
     expect(result.actions).toContain('quarantined_corrupt_db');
+    expect(result.actions).toContain('quarantined_corrupt_wal');
+    expect(result.actions).toContain('quarantined_corrupt_shm');
     expect(existsSync(dbPath)).toBe(false);
     expect(existsSync(dbPath + '-wal')).toBe(false);
     expect(existsSync(dbPath + '-shm')).toBe(false);
 
     const entries = await fs.readdir(dir);
     expect(entries.some((entry) => entry.startsWith('librarian.sqlite.corrupt.'))).toBe(true);
+    expect(entries.some((entry) => entry.startsWith('librarian.sqlite-wal.corrupt.'))).toBe(true);
+    expect(entries.some((entry) => entry.startsWith('librarian.sqlite-shm.corrupt.'))).toBe(true);
+  });
+
+  it('restores an empty primary store from the most viable snapshot backup', async () => {
+    const dir = await createTempDir();
+    tempDirs.push(dir);
+    const primaryDbPath = path.join(dir, 'librarian.sqlite');
+    const backupDbPath = `${primaryDbPath}.bak.good`;
+
+    const primaryStorage = createSqliteStorage(primaryDbPath, dir);
+    await primaryStorage.initialize();
+    await primaryStorage.close();
+
+    const backupStorage = createSqliteStorage(backupDbPath, dir);
+    await backupStorage.initialize();
+    await backupStorage.upsertFunction({
+      id: 'fn:1',
+      filePath: path.join(dir, 'src', 'query.ts'),
+      name: 'queryPipeline',
+      signature: 'queryPipeline(): void',
+      purpose: 'Implements the query pipeline',
+      startLine: 1,
+      endLine: 3,
+      confidence: 0.9,
+      accessCount: 0,
+      lastAccessed: null,
+      validationCount: 0,
+      outcomeHistory: { successes: 0, failures: 0 },
+    });
+    await backupStorage.upsertModule({
+      id: 'mod:1',
+      path: path.join(dir, 'src', 'query.ts'),
+      purpose: 'Query pipeline module',
+      exports: ['queryPipeline'],
+      dependencies: [],
+      confidence: 0.9,
+    });
+    await backupStorage.close();
+
+    const result = await recoverPrimaryFromViableSnapshot(primaryDbPath);
+
+    expect(result.recovered).toBe(true);
+    expect(result.actions).toContain('archived_empty_primary');
+    expect(result.actions).toContain('restored_primary_from_snapshot');
+
+    const restoredStorage = createSqliteStorage(primaryDbPath, dir);
+    await restoredStorage.initialize();
+    try {
+      const stats = await restoredStorage.getStats();
+      expect(stats.totalFunctions).toBe(1);
+      expect(stats.totalModules).toBe(1);
+    } finally {
+      await restoredStorage.close();
+    }
+
+    const entries = await fs.readdir(dir);
+    expect(entries.some((entry) => entry.startsWith('librarian.sqlite.empty.'))).toBe(true);
   });
 
   it('deduplicates repeated no-action recovery warnings for the same lock state', async () => {

--- a/src/storage/__tests__/symbol_storage.test.ts
+++ b/src/storage/__tests__/symbol_storage.test.ts
@@ -1,0 +1,45 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createSymbolStorageWithPath } from '../symbol_storage.js';
+
+describe('SymbolStorage recovery', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it('recreates malformed symbol databases during initialize', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'librarian-symbol-storage-'));
+    tempDirs.push(dir);
+
+    const dbPath = path.join(dir, 'knowledge.db');
+    await fs.writeFile(dbPath, 'not-a-sqlite-database', 'utf8');
+
+    const storage = createSymbolStorageWithPath(dbPath);
+    await storage.initialize();
+
+    try {
+      storage.upsertSymbols([
+        {
+          name: 'queryPipeline',
+          kind: 'function',
+          file: 'src/api/query.ts',
+          line: 12,
+          endLine: 18,
+          exported: true,
+          qualifiedName: 'src/api/query.ts:queryPipeline',
+        },
+      ]);
+
+      const results = storage.findByExactName('queryPipeline');
+      expect(results).toHaveLength(1);
+      expect(results[0]?.file).toBe('src/api/query.ts');
+    } finally {
+      await storage.close();
+    }
+  });
+});

--- a/src/storage/sqlite_storage.ts
+++ b/src/storage/sqlite_storage.ts
@@ -630,7 +630,7 @@ export class SqliteLiBrainianStorage implements LiBrainianStorage {
         throw new Error(`indexing in progress (pid=${observed.pid}, startedAt=${observed.startedAt})`);
       }
 
-      const recovery = await attemptStorageRecovery(this.dbPath).catch((recoveryError) => ({
+      const recovery = await attemptStorageRecovery(this.dbPath, { mode: 'stale_lock' }).catch((recoveryError) => ({
         recovered: false,
         actions: [] as string[],
         errors: [String(recoveryError)],
@@ -663,7 +663,7 @@ export class SqliteLiBrainianStorage implements LiBrainianStorage {
 
         // Proactively clear stale lock artifacts from prior interrupted runs.
         try {
-          const proactiveRecovery = await attemptStorageRecovery(this.dbPath);
+          const proactiveRecovery = await attemptStorageRecovery(this.dbPath, { mode: 'stale_lock' });
           if (proactiveRecovery.recovered) {
             logDedupedLockDiagnostic('Recovered stale lock state before acquisition', {
               path: this.lockPath,
@@ -681,7 +681,10 @@ export class SqliteLiBrainianStorage implements LiBrainianStorage {
         try {
           await this.acquireProcessLock();
         } catch (error) {
-          const recovery = await attemptStorageRecovery(this.dbPath, { error }).catch((recoveryError) => ({
+          const recovery = await attemptStorageRecovery(this.dbPath, {
+            error,
+            mode: 'stale_lock',
+          }).catch((recoveryError) => ({
             recovered: false,
             actions: [] as string[],
             errors: [String(recoveryError)],
@@ -710,7 +713,10 @@ export class SqliteLiBrainianStorage implements LiBrainianStorage {
         this.db.pragma('foreign_keys = ON');
         this.db.pragma('busy_timeout = 5000');
 
-        await applyMigrations(this.db, this.workspaceRoot);
+        await applyMigrations(this.db, {
+          workspaceRoot: this.workspaceRoot,
+          dbPath: this.dbPath,
+        });
         this.ensureEmbeddingColumns();
         this.ensureGraphTables();
         this.ensureTemporalTables();
@@ -750,7 +756,10 @@ export class SqliteLiBrainianStorage implements LiBrainianStorage {
 
         if (!attemptedCorruptionRecovery && this.dbPath !== ':memory:' && isRecoverableStorageError(error)) {
           attemptedCorruptionRecovery = true;
-          const recovery = await attemptStorageRecovery(this.dbPath, { error }).catch((recoveryError) => ({
+          const recovery = await attemptStorageRecovery(this.dbPath, {
+            error,
+            mode: 'quarantine_corrupt',
+          }).catch((recoveryError) => ({
             recovered: false,
             actions: [] as string[],
             errors: [String(recoveryError)],

--- a/src/storage/storage_recovery.ts
+++ b/src/storage/storage_recovery.ts
@@ -1,3 +1,4 @@
+import Database from 'better-sqlite3';
 import * as fs from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import * as path from 'node:path';
@@ -11,6 +12,11 @@ export interface StorageRecoveryResult {
 
 export interface StorageRecoveryOptions {
   error?: unknown;
+  mode?: 'stale_lock' | 'quarantine_corrupt';
+}
+
+export interface SnapshotRecoveryOptions {
+  additionalCandidates?: string[];
 }
 
 const LOCK_STALE_TIMEOUT_MS = 15 * 60_000;
@@ -150,6 +156,8 @@ export async function attemptStorageRecovery(
   const lockPath = `${dbPath}.lock`;
   const walPath = `${dbPath}-wal`;
   const shmPath = `${dbPath}-shm`;
+  const mode = options.mode
+    ?? (isCorruptionStorageError(options.error) ? 'quarantine_corrupt' : 'stale_lock');
 
   let lockBlocked = false;
 
@@ -189,33 +197,27 @@ export async function attemptStorageRecovery(
     }
   }
 
-  if (!lockBlocked) {
-    if (existsSync(walPath)) {
-      await fs.unlink(walPath).catch((error) => {
-        errors.push(`wal_unlink_failed:${String(error)}`);
-      });
-      actions.push('removed_wal');
-    }
-    if (existsSync(shmPath)) {
-      await fs.unlink(shmPath).catch((error) => {
-        errors.push(`shm_unlink_failed:${String(error)}`);
-      });
-      actions.push('removed_shm');
-    }
-
-    if (isCorruptionStorageError(options.error) && existsSync(dbPath)) {
-      const quarantinePath = `${dbPath}.corrupt.${Date.now()}`;
+  if (!lockBlocked && mode === 'quarantine_corrupt') {
+    const timestamp = Date.now();
+    const quarantinePaths: Array<{ sourcePath: string; kind: 'db' | 'wal' | 'shm' }> = [
+      { sourcePath: dbPath, kind: 'db' },
+      { sourcePath: walPath, kind: 'wal' },
+      { sourcePath: shmPath, kind: 'shm' },
+    ];
+    for (const entry of quarantinePaths) {
+      if (!existsSync(entry.sourcePath)) continue;
+      const quarantinePath = `${entry.sourcePath}.corrupt.${timestamp}`;
       try {
-        await fs.rename(dbPath, quarantinePath);
-        actions.push('quarantined_corrupt_db');
+        await fs.rename(entry.sourcePath, quarantinePath);
+        actions.push(
+          entry.kind === 'db'
+            ? 'quarantined_corrupt_db'
+            : entry.kind === 'wal'
+              ? 'quarantined_corrupt_wal'
+              : 'quarantined_corrupt_shm'
+        );
       } catch (renameError) {
-        errors.push(`db_quarantine_failed:${String(renameError)}`);
-        await fs.unlink(dbPath).catch((unlinkError) => {
-          errors.push(`db_unlink_failed:${String(unlinkError)}`);
-        });
-        if (!existsSync(dbPath)) {
-          actions.push('removed_corrupt_db');
-        }
+        errors.push(`${entry.kind}_quarantine_failed:${String(renameError)}`);
       }
     }
   }
@@ -241,6 +243,169 @@ export async function attemptStorageRecovery(
   }
 
   return { recovered: actions.length > 0 && !lockBlocked, actions, errors };
+}
+
+interface StorageSnapshotStats {
+  path: string;
+  totalCoreRows: number;
+  mtimeMs: number;
+}
+
+function readTableCount(db: Database.Database, tableName: string): number {
+  const row = db
+    .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(tableName) as { 1?: number } | undefined;
+  if (!row) return 0;
+  const countRow = db.prepare(`SELECT COUNT(*) as count FROM ${tableName}`).get() as { count?: number } | undefined;
+  return typeof countRow?.count === 'number' && Number.isFinite(countRow.count) ? countRow.count : 0;
+}
+
+async function inspectSnapshot(dbPath: string): Promise<StorageSnapshotStats | null> {
+  if (!existsSync(dbPath)) return null;
+  let db: Database.Database | null = null;
+  try {
+    const stat = await fs.stat(dbPath);
+    db = new Database(dbPath, { readonly: true, fileMustExist: true });
+    const totalCoreRows =
+      readTableCount(db, 'librarian_functions')
+      + readTableCount(db, 'librarian_modules')
+      + readTableCount(db, 'librarian_context_packs')
+      + readTableCount(db, 'librarian_files')
+      + readTableCount(db, 'librarian_embeddings')
+      + readTableCount(db, 'librarian_ingested_items')
+      + readTableCount(db, 'librarian_directories');
+    return {
+      path: dbPath,
+      totalCoreRows,
+      mtimeMs: stat.mtimeMs,
+    };
+  } catch {
+    return null;
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // Ignore best-effort cleanup failures.
+    }
+  }
+}
+
+async function discoverSnapshotCandidates(
+  primaryDbPath: string,
+  options: SnapshotRecoveryOptions
+): Promise<string[]> {
+  const candidates = new Set<string>();
+  for (const candidate of options.additionalCandidates ?? []) {
+    if (candidate && candidate !== primaryDbPath) {
+      candidates.add(candidate);
+    }
+  }
+
+  const directory = path.dirname(primaryDbPath);
+  const primaryFileName = path.basename(primaryDbPath);
+  try {
+    const entries = await fs.readdir(directory);
+    for (const entry of entries) {
+      if (!entry.startsWith(`${primaryFileName}.bak.`)) continue;
+      if (entry.includes('-wal.bak.') || entry.includes('-shm.bak.')) continue;
+      candidates.add(path.join(directory, entry));
+    }
+  } catch {
+    // Ignore unreadable directories and return only explicit candidates.
+  }
+
+  return Array.from(candidates);
+}
+
+async function archivePrimaryArtifacts(primaryDbPath: string, archiveSuffix: string): Promise<string[]> {
+  const archived: string[] = [];
+  const suffixes = ['', '-wal', '-shm'];
+  for (const suffix of suffixes) {
+    const sourcePath = `${primaryDbPath}${suffix}`;
+    if (!existsSync(sourcePath)) continue;
+    const archivedPath = `${sourcePath}.empty.${archiveSuffix}`;
+    await fs.rename(sourcePath, archivedPath);
+    archived.push(archivedPath);
+  }
+  return archived;
+}
+
+async function removePrimarySidecars(primaryDbPath: string): Promise<void> {
+  await Promise.all(
+    ['-wal', '-shm'].map(async (suffix) => {
+      try {
+        await fs.unlink(`${primaryDbPath}${suffix}`);
+      } catch {
+        // Ignore missing sidecars.
+      }
+    })
+  );
+}
+
+async function installSnapshotArtifacts(primaryDbPath: string, snapshotPath: string): Promise<void> {
+  await removePrimarySidecars(primaryDbPath);
+  await fs.copyFile(snapshotPath, primaryDbPath);
+  for (const suffix of ['-wal', '-shm']) {
+    const sourcePath = `${snapshotPath}${suffix}`;
+    const targetPath = `${primaryDbPath}${suffix}`;
+    if (!existsSync(sourcePath)) continue;
+    await fs.copyFile(sourcePath, targetPath);
+  }
+}
+
+export async function recoverPrimaryFromViableSnapshot(
+  primaryDbPath: string,
+  options: SnapshotRecoveryOptions = {}
+): Promise<StorageRecoveryResult> {
+  const actions: string[] = [];
+  const errors: string[] = [];
+  if (!primaryDbPath || primaryDbPath === ':memory:') {
+    return { recovered: false, actions, errors: ['memory_storage'] };
+  }
+
+  const primaryStats = await inspectSnapshot(primaryDbPath);
+  if (primaryStats && primaryStats.totalCoreRows > 0) {
+    return { recovered: false, actions, errors };
+  }
+
+  const candidatePaths = await discoverSnapshotCandidates(primaryDbPath, options);
+  const candidateStats = (
+    await Promise.all(candidatePaths.map((candidatePath) => inspectSnapshot(candidatePath)))
+  ).filter((stats): stats is StorageSnapshotStats => stats !== null && stats.totalCoreRows > 0);
+
+  if (candidateStats.length === 0) {
+    return { recovered: false, actions, errors: ['no_viable_snapshot'] };
+  }
+
+  candidateStats.sort((left, right) =>
+    right.totalCoreRows - left.totalCoreRows || right.mtimeMs - left.mtimeMs
+  );
+  const bestSnapshot = candidateStats[0];
+  const archiveSuffix = String(Date.now());
+
+  try {
+    const archived = await archivePrimaryArtifacts(primaryDbPath, archiveSuffix);
+    if (archived.length > 0) {
+      actions.push('archived_empty_primary');
+    }
+    await installSnapshotArtifacts(primaryDbPath, bestSnapshot.path);
+    actions.push('restored_primary_from_snapshot');
+    logInfo('[storage-recovery] restored empty primary storage from viable snapshot', {
+      primaryDbPath,
+      snapshotPath: bestSnapshot.path,
+      snapshotCoreRows: bestSnapshot.totalCoreRows,
+      previousPrimaryCoreRows: primaryStats?.totalCoreRows ?? 0,
+    });
+    return { recovered: true, actions, errors };
+  } catch (error) {
+    errors.push(`snapshot_restore_failed:${String(error)}`);
+    logWarning('[storage-recovery] failed to restore empty primary storage from viable snapshot', {
+      primaryDbPath,
+      snapshotPath: bestSnapshot.path,
+      error: String(error),
+    });
+    return { recovered: false, actions, errors };
+  }
 }
 
 async function inspectSingleWorkspaceLock(lockPath: string): Promise<{

--- a/src/storage/symbol_storage.ts
+++ b/src/storage/symbol_storage.ts
@@ -19,6 +19,7 @@ import * as path from 'path';
 import * as fs from 'fs/promises';
 import type { SymbolEntry, SymbolKind } from '../constructions/symbol_table.js';
 import { SymbolTable } from '../constructions/symbol_table.js';
+import { attemptStorageRecovery, isRecoverableStorageError } from './storage_recovery.js';
 
 // ============================================================================
 // TYPES
@@ -75,13 +76,19 @@ export class SymbolStorage {
     if (this.initialized) return;
 
     await fs.mkdir(path.dirname(this.dbPath), { recursive: true });
+    try {
+      this.openDatabase();
+      this.initialized = true;
+    } catch (error) {
+      this.resetDbHandle();
+      if (!isRecoverableStorageError(error)) {
+        throw error;
+      }
 
-    this.db = new Database(this.dbPath);
-    this.db.pragma('journal_mode = WAL');
-    this.db.pragma('synchronous = NORMAL');
-
-    this.ensureSymbolTable();
-    this.initialized = true;
+      await attemptStorageRecovery(this.dbPath, { error, mode: 'quarantine_corrupt' });
+      this.openDatabase();
+      this.initialized = true;
+    }
   }
 
   /**
@@ -107,6 +114,23 @@ export class SymbolStorage {
       throw new Error('SymbolStorage not initialized. Call initialize() first.');
     }
     return this.db;
+  }
+
+  private openDatabase(): void {
+    this.db = new Database(this.dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('synchronous = NORMAL');
+    this.ensureSymbolTable();
+  }
+
+  private resetDbHandle(): void {
+    if (!this.db) return;
+    try {
+      this.db.close();
+    } catch {
+      // Best-effort cleanup before recovery.
+    }
+    this.db = null;
   }
 
   private ensureSymbolTable(): void {


### PR DESCRIPTION
## Summary
- repair the cross-provider fallback/query recovery path so degraded runs still return usable results instead of drifting into unrelated files or failing analysis output
- harden query/bootstrap/storage recovery around empty or corrupt SQLite state, detached temp databases, snapshot reuse, and ephemeral query storage
- add regression coverage for filesystem fallback ranking, architecture/query routing, storage recovery, symbol recovery, swarm checkpoints, and the #907 verifier suites

## Verification
- npm run build
- npm test -- --run
- npm test -- --run src/constructions/processes/__tests__/hallucinated_api_detector.test.ts src/__tests__/github_readiness_docs.test.ts src/constructions/processes/__tests__/context_pack_depth_gate.test.ts src/__tests__/e2e_cadence_workflow.test.ts src/cli/commands/__tests__/coverage.test.ts
- ./ask --json "Where is the query pipeline implemented and what are its stages?"
- node scripts/issue-quality-analysis.mjs 907 --description "cross-provider model normalization" --verdict improved --assessment "Fallback/provider normalization and follow-on query-path repairs now produce usable answers again. The query-pipeline question resolves to src/api/query.ts instead of drifting into unrelated files, issue analysis completes and writes its artifact, and full finite validation is green." --concerns "Live retrieval still shows degraded semantic signals in some environments, so provider/index health remains worth watching even though the user-facing answer and finite gate are now good."

Closes #907