### PR TITLE
fix: preserve llm fallback in nested sessions

### DIFF
--- a/src/__tests__/adapters/cli_llm_service.test.ts
+++ b/src/__tests__/adapters/cli_llm_service.test.ts
@@ -121,23 +121,16 @@ describe('CliLlmService provider routing', () => {
     expect(execaMock.mock.calls[0]?.[0]).toBe('codex');
   });
 
-  it('reports claude available in nested sessions via env stripping (no ANTHROPIC_API_KEY needed)', async () => {
+  it('reports claude unavailable in nested sessions when no API/broker escape hatch exists', async () => {
     delete process.env.ANTHROPIC_API_KEY;
     process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '8192';
-
-    execaMock.mockResolvedValueOnce({
-      exitCode: 0,
-      stdout: '2.1.62 (Claude Code)',
-      stderr: '',
-    } as never);
 
     const service = new CliLlmService();
     const health = await service.checkClaudeHealth();
 
-    // Nested sessions no longer block — env vars are stripped before spawning
-    expect(health.available).toBe(true);
-    expect(execaMock).toHaveBeenCalled();
-    expect(execaMock.mock.calls[0]?.[0]).toBe('claude');
+    expect(health.available).toBe(false);
+    expect(health.error).toContain('Nested Claude Code session detected');
+    expect(execaMock).not.toHaveBeenCalled();
   });
 
   it('reports claude available via API transport in nested sessions when ANTHROPIC_API_KEY is set', async () => {
@@ -439,12 +432,12 @@ describe('CliLlmService provider routing', () => {
     expect(execaMock.mock.calls[0]?.[0]).toBe('claude');
   });
 
-  it('uses Claude CLI in nested sessions via env stripping (no codex fallback)', async () => {
+  it('rejects Claude CLI entirely in nested sessions without API/broker fallbacks', async () => {
     delete process.env.ANTHROPIC_API_KEY;
     process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '8192';
     execaMock.mockResolvedValue({
       exitCode: 0,
-      stdout: 'claude-answer',
+      stdout: 'codex-fallback',
       stderr: '',
     } as never);
 
@@ -454,11 +447,10 @@ describe('CliLlmService provider routing', () => {
       messages: [{ role: 'user', content: 'hello' }],
     });
 
-    // Nested sessions no longer block Claude CLI — env vars are stripped
-    expect(result.provider).toBe('claude');
-    expect(result.content).toContain('claude-answer');
-    expect(execaMock).toHaveBeenCalledTimes(1);
-    expect(execaMock.mock.calls[0]?.[0]).toBe('claude');
+    expect(result.provider).toBe('codex');
+    expect(result.content).toContain('codex-fallback');
+    const claudeCall = execaMock.mock.calls.find((call) => call[0] === 'claude');
+    expect(claudeCall).toBeUndefined();
   });
 
   it('falls back to codex when claude fails', async () => {

--- a/src/adapters/cli_llm_service.ts
+++ b/src/adapters/cli_llm_service.ts
@@ -14,6 +14,13 @@ import {
 } from '../utils/provider_failures.js';
 import { isPrivacyModeStrict } from '../utils/runtime_controls.js';
 import { appendPrivacyAuditEvent } from '../security/privacy_audit.js';
+import { CLAUDE_NESTED_SESSION_ENV_VARS, detectNestedClaudeSession } from '../api/nested_session.js';
+import {
+  hasEnvValue,
+  shouldUseAnthropicApiTransport,
+  shouldUseClaudeBrokerTransport,
+  shouldUseOpenAiApiTransport,
+} from '../api/llm_transport_env.js';
 import {
   ProviderChaosMiddleware,
   createProviderChaosConfigFromEnv,
@@ -26,8 +33,6 @@ type GovernorContextLike = { checkBudget: () => void; recordTokens: (tokens: num
 type ChatResult = { content: string; provider: string };
 
 type CliProvider = 'claude' | 'codex';
-type ProviderTransport = 'auto' | 'cli' | 'api' | 'broker';
-
 type HealthState = {
   claude: LlmProviderHealth;
   codex: LlmProviderHealth;
@@ -113,17 +118,6 @@ function estimateTokenCount(text: string): number {
   return trimmed ? Math.max(1, Math.ceil(trimmed.length / 4)) : 1;
 }
 
-/** Env vars that Claude Code sets to detect nested sessions. */
-const NESTED_SESSION_VARS = [
-  'CLAUDECODE',
-  'CLAUDE_CODE',
-  'CLAUDE_CODE_ENTRYPOINT',
-  'CLAUDE_CODE_SESSION_ID',
-  'CLAUDE_CODE_MAX_OUTPUT_TOKENS',
-  'CLAUDE_SESSION',
-  'SESSION_ID',
-];
-
 function withCliPath(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const home = process.env.HOME || '';
   const prefix = home ? path.join(home, '.local', 'bin') : '';
@@ -141,7 +135,7 @@ function withCliPath(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
  */
 function sanitizedCliEnv(overrides?: Record<string, string>): NodeJS.ProcessEnv {
   const env = withCliPath({ ...process.env, ...(overrides ?? {}) });
-  for (const key of NESTED_SESSION_VARS) {
+  for (const key of CLAUDE_NESTED_SESSION_ENV_VARS) {
     delete env[key];
   }
   return env;
@@ -152,32 +146,6 @@ function coerceGovernorContext(value: unknown): GovernorContextLike | null {
   return candidate && typeof candidate.checkBudget === 'function' && typeof candidate.recordTokens === 'function'
     ? candidate
     : null;
-}
-
-function hasEnvValue(value: string | undefined): boolean {
-  return typeof value === 'string' && value.trim().length > 0;
-}
-
-function isNestedClaudeCodeSession(): boolean {
-  return hasEnvValue(process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS)
-    || hasEnvValue(process.env.CLAUDE_CODE_SESSION_ID)
-    || hasEnvValue(process.env.CLAUDECODE);
-}
-
-function parseTransport(value: string | undefined): ProviderTransport {
-  const normalized = value?.trim().toLowerCase();
-  if (normalized === 'cli' || normalized === 'api' || normalized === 'auto' || normalized === 'broker') {
-    return normalized;
-  }
-  return 'auto';
-}
-
-function resolveClaudeTransportMode(): ProviderTransport {
-  return parseTransport(process.env.LIBRARIAN_CLAUDE_TRANSPORT ?? process.env.LIBRARIAN_LLM_CLAUDE_TRANSPORT);
-}
-
-function resolveCodexTransportMode(): ProviderTransport {
-  return parseTransport(process.env.LIBRARIAN_CODEX_TRANSPORT ?? process.env.LIBRARIAN_LLM_CODEX_TRANSPORT);
 }
 
 function resolveClaudeBrokerBaseUrl(): string | null {
@@ -222,34 +190,16 @@ function resolveClaudeBrokerHealthUrl(): string | null {
   return url.toString();
 }
 
-function shouldUseAnthropicApiTransport(): boolean {
-  const mode = resolveClaudeTransportMode();
-  if (mode === 'broker') return false;
-  if (mode === 'api') return true;
-  if (mode === 'cli') return false;
-  if (!hasEnvValue(process.env.ANTHROPIC_API_KEY)) return false;
-  return true;
-}
-
-function shouldUseClaudeBrokerTransport(): boolean {
-  const mode = resolveClaudeTransportMode();
-  const brokerConfigured = Boolean(resolveClaudeBrokerBaseUrl());
-  if (!brokerConfigured) return false;
-  if (mode === 'broker') return true;
-  if (mode === 'api' || mode === 'cli') return false;
-  return true;
-}
-
-function shouldUseOpenAiApiTransport(): boolean {
-  if (!hasEnvValue(process.env.OPENAI_API_KEY)) return false;
-  const mode = resolveCodexTransportMode();
-  if (mode === 'api') return true;
-  if (mode === 'cli') return false;
-  return true;
-}
-
 function buildNestedClaudeUnavailableMessage(): string {
   return 'Claude CLI cannot run inside nested Claude Code sessions; set ANTHROPIC_API_KEY for API transport, set LIBRARIAN_CLAUDE_BROKER_URL for broker transport, or switch provider.';
+}
+
+function resolveNestedClaudeBlockReason(): string | undefined {
+  const detection = detectNestedClaudeSession();
+  if (!detection.isNested) return undefined;
+  if (shouldUseAnthropicApiTransport() || shouldUseClaudeBrokerTransport()) return undefined;
+  const markers = detection.markers.length > 0 ? detection.markers.join(', ') : 'unknown markers';
+  return `Nested Claude Code session detected (${markers}). ${buildNestedClaudeUnavailableMessage()}`;
 }
 
 function normalizeAnthropicModelId(modelId: string | undefined): string {
@@ -583,6 +533,18 @@ export class CliLlmService {
     const cached = this.health.claude;
     if (!forceCheck && cached.lastCheck && now - cached.lastCheck < this.healthCheckIntervalMs) {
       return cached;
+    }
+
+    const nestedBlockReason = resolveNestedClaudeBlockReason();
+    if (nestedBlockReason) {
+      this.health.claude = {
+        provider: 'claude',
+        available: false,
+        authenticated: false,
+        lastCheck: now,
+        error: nestedBlockReason,
+      };
+      return this.health.claude;
     }
 
     if (shouldUseAnthropicApiTransport()) {
@@ -1127,6 +1089,11 @@ export class CliLlmService {
       const args = ['--print'];
       if (systemPrompt) {
         args.push('--system-prompt', systemPrompt);
+      }
+      const nestedBlockReason = resolveNestedClaudeBlockReason();
+      if (nestedBlockReason) {
+        await this.recordFailure('claude', nestedBlockReason, nestedBlockReason);
+        throw new Error(`unverified_by_trace(provider_unavailable): ${nestedBlockReason}`);
       }
       const env = sanitizedCliEnv(options.modelId ? { CLAUDE_MODEL: options.modelId } : undefined);
       logInfo('CLI LLM: claude call', { promptLength: fullPrompt.length });

--- a/src/api/__tests__/bootstrap_status.test.ts
+++ b/src/api/__tests__/bootstrap_status.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const envSnapshot = { ...process.env };
+const NESTED_MARKER_KEYS = [
+  'CLAUDE_CODE',
+  'CLAUDECODE',
+  'CLAUDE_CODE_ENTRYPOINT',
+  'CLAUDE_CODE_SESSION',
+  'CLAUDE_CODE_SESSION_ID',
+  'CLAUDE_CODE_MAX_OUTPUT_TOKENS',
+  'CLAUDE_SESSION',
+  'SESSION_ID',
+  'ANTHROPIC_CLAUDE_CODE',
+  'ANTHROPIC_CLAUDE_CODE_SESSION',
+] as const;
+
+function restoreEnv(snapshot: NodeJS.ProcessEnv) {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in snapshot)) {
+      delete process.env[key];
+    }
+  }
+  Object.assign(process.env, snapshot);
+}
+
+describe('getBootstrapStatus', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    restoreEnv(envSnapshot);
+    for (const key of NESTED_MARKER_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    restoreEnv(envSnapshot);
+    for (const key of NESTED_MARKER_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  it('returns default bootstrap status with llm synthesis when no nested markers are present', async () => {
+    const { getBootstrapStatus } = await import('../bootstrap.js');
+    const status = getBootstrapStatus('/tmp/workspace');
+    expect(status.status).toBe('not_started');
+    expect(status.synthesis?.synthesisMode).toBe('llm');
+  });
+
+  it('returns structural-only synthesis metadata when nested Claude markers are set without an alternate route', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.LIBRARIAN_CLAUDE_BROKER_URL;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.LIBRARIAN_LLM_PROVIDER;
+    delete process.env.CODEX_HOME;
+    delete process.env.CODEX_MODEL;
+    delete process.env.CODEX_PROFILE;
+    process.env.CLAUDE_CODE_SESSION = '1';
+
+    const { getBootstrapStatus } = await import('../bootstrap.js');
+    const status = getBootstrapStatus('/tmp/workspace');
+
+    expect(status.status).toBe('not_started');
+    expect(status.synthesis?.synthesisMode).toBe('structural-only');
+    expect(status.synthesis?.synthesisUnavailableReason).toMatch(/nested claude code session/i);
+  });
+});

--- a/src/api/__tests__/llm_env.test.ts
+++ b/src/api/__tests__/llm_env.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const envSnapshot = { ...process.env };
+const NESTED_MARKER_KEYS = [
+  'CLAUDE_CODE',
+  'CLAUDECODE',
+  'CLAUDE_CODE_ENTRYPOINT',
+  'CLAUDE_CODE_SESSION',
+  'CLAUDE_CODE_SESSION_ID',
+  'CLAUDE_CODE_MAX_OUTPUT_TOKENS',
+  'CLAUDE_SESSION',
+  'SESSION_ID',
+  'ANTHROPIC_CLAUDE_CODE',
+  'ANTHROPIC_CLAUDE_CODE_SESSION',
+] as const;
+
+function restoreEnv(snapshot: NodeJS.ProcessEnv) {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in snapshot)) {
+      delete process.env[key];
+    }
+  }
+  Object.assign(process.env, snapshot);
+}
+
+describe('resolveSynthesisAvailability', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    restoreEnv(envSnapshot);
+    for (const key of NESTED_MARKER_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    restoreEnv(envSnapshot);
+    for (const key of NESTED_MARKER_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  it('returns structural-only when nested Claude session markers are present without an alternate route', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.LIBRARIAN_CLAUDE_BROKER_URL;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.LIBRARIAN_LLM_PROVIDER;
+    delete process.env.CODEX_HOME;
+    delete process.env.CODEX_MODEL;
+    delete process.env.CODEX_PROFILE;
+    process.env.CLAUDE_CODE_SESSION = '1';
+
+    const { resolveSynthesisAvailability } = await import('../llm_env.js');
+    const availability = resolveSynthesisAvailability();
+
+    expect(availability.synthesisMode).toBe('structural-only');
+    expect(availability.synthesisUnavailableReason).toMatch(/Nested Claude Code session detected/);
+  });
+
+  it('returns llm mode when nested sessions have codex configured', async () => {
+    process.env.CLAUDE_CODE_SESSION = '1';
+    process.env.LIBRARIAN_LLM_PROVIDER = 'codex';
+
+    const { resolveSynthesisAvailability } = await import('../llm_env.js');
+
+    expect(resolveSynthesisAvailability()).toEqual({ synthesisMode: 'llm' });
+  });
+
+  it('returns llm mode when nested sessions have Anthropic API transport configured', async () => {
+    process.env.CLAUDE_CODE_SESSION = '1';
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key';
+
+    const { resolveSynthesisAvailability } = await import('../llm_env.js');
+
+    expect(resolveSynthesisAvailability()).toEqual({ synthesisMode: 'llm' });
+  });
+
+  it('returns llm mode when nested sessions have Claude broker transport configured', async () => {
+    process.env.CLAUDE_CODE_SESSION = '1';
+    process.env.LIBRARIAN_CLAUDE_BROKER_URL = 'http://127.0.0.1:8787';
+
+    const { resolveSynthesisAvailability } = await import('../llm_env.js');
+
+    expect(resolveSynthesisAvailability()).toEqual({ synthesisMode: 'llm' });
+  });
+});

--- a/src/api/__tests__/llm_provider_discovery.test.ts
+++ b/src/api/__tests__/llm_provider_discovery.test.ts
@@ -32,6 +32,18 @@ const cleanupTasks: Array<() => void> = [];
 const envSnapshot = { ...process.env };
 const execaMock = vi.mocked(execa);
 const TEST_MAX_CLI_BINARY_BYTES = 50 * 1024 * 1024;
+const NESTED_MARKER_KEYS = [
+  'CLAUDE_CODE',
+  'CLAUDECODE',
+  'CLAUDE_CODE_ENTRYPOINT',
+  'CLAUDE_CODE_SESSION',
+  'CLAUDE_CODE_SESSION_ID',
+  'CLAUDE_CODE_MAX_OUTPUT_TOKENS',
+  'CLAUDE_SESSION',
+  'SESSION_ID',
+  'ANTHROPIC_CLAUDE_CODE',
+  'ANTHROPIC_CLAUDE_CODE_SESSION',
+] as const;
 
 function buildExecaResult(options: { exitCode: number; stdout?: string; stderr?: string }) {
   return {
@@ -88,6 +100,9 @@ beforeEach(() => {
   manifestState.hashes.codex.length = 0;
   execaMock.mockReset();
   restoreEnv(envSnapshot);
+  for (const key of NESTED_MARKER_KEYS) {
+    delete process.env[key];
+  }
 });
 
 afterEach(() => {
@@ -102,6 +117,9 @@ afterEach(() => {
   }
   savedProbes.clear();
   restoreEnv(envSnapshot);
+  for (const key of NESTED_MARKER_KEYS) {
+    delete process.env[key];
+  }
 });
 
 describe('llm provider discovery', () => {
@@ -179,22 +197,9 @@ describe('llm provider discovery', () => {
     expect(discovered?.modelId).toBe('codex-model');
   });
 
-  it('prefers claude during nested Claude Code sessions (env stripping makes CLI work)', async () => {
+  it('skips claude CLI probing during nested Claude Code sessions and selects codex', async () => {
     process.env.CLAUDE_CODE_ENTRYPOINT = '1';
 
-    const claudeProbe: LlmProviderProbe = {
-      descriptor: {
-        id: 'claude',
-        name: 'Claude',
-        authMethod: 'cli_login',
-        defaultModel: 'claude-model',
-        priority: 10,
-        supportsEmbeddings: false,
-        supportsChat: true,
-      },
-      envVars: [],
-      probe: async () => ({ available: true, authenticated: true }),
-    };
     const codexProbe: LlmProviderProbe = {
       descriptor: {
         id: 'codex',
@@ -209,32 +214,17 @@ describe('llm provider discovery', () => {
       probe: async () => ({ available: true, authenticated: true }),
     };
 
-    llmProviderRegistry.register(claudeProbe);
+    llmProviderRegistry.register(claudeCliProbe);
     llmProviderRegistry.register(codexProbe);
 
     const discovered = await discoverLlmProvider({ forceRefresh: true });
-    // Nested sessions no longer force codex fallback — Claude CLI works via env stripping
-    expect(discovered?.provider).toBe('claude');
-    expect(discovered?.modelId).toBe('claude-model');
+    expect(discovered?.provider).toBe('codex');
+    expect(discovered?.modelId).toBe('codex-model');
   });
 
-  it('prefers claude during nested Claude Code sessions when ANTHROPIC_API_KEY is configured', async () => {
+  it('keeps claude available during nested sessions when ANTHROPIC_API_KEY is configured', async () => {
     process.env.CLAUDE_CODE_ENTRYPOINT = '1';
     process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key';
-
-    const claudeProbe: LlmProviderProbe = {
-      descriptor: {
-        id: 'claude',
-        name: 'Claude',
-        authMethod: 'cli_login',
-        defaultModel: 'claude-model',
-        priority: 10,
-        supportsEmbeddings: false,
-        supportsChat: true,
-      },
-      envVars: [],
-      probe: async () => ({ available: true, authenticated: true }),
-    };
     const codexProbe: LlmProviderProbe = {
       descriptor: {
         id: 'codex',
@@ -249,31 +239,17 @@ describe('llm provider discovery', () => {
       probe: async () => ({ available: true, authenticated: true }),
     };
 
-    llmProviderRegistry.register(claudeProbe);
+    llmProviderRegistry.register(claudeCliProbe);
     llmProviderRegistry.register(codexProbe);
 
     const discovered = await discoverLlmProvider({ forceRefresh: true });
     expect(discovered?.provider).toBe('claude');
-    expect(discovered?.modelId).toBe('claude-model');
+    expect(discovered?.modelId).toBe(claudeCliProbe.descriptor.defaultModel);
   });
 
-  it('prefers claude during nested Claude Code sessions when Claude broker is configured', async () => {
+  it('keeps claude available during nested sessions when Claude broker is configured', async () => {
     process.env.CLAUDE_CODE_ENTRYPOINT = '1';
     process.env.LIBRARIAN_CLAUDE_BROKER_URL = 'http://127.0.0.1:8787';
-
-    const claudeProbe: LlmProviderProbe = {
-      descriptor: {
-        id: 'claude',
-        name: 'Claude',
-        authMethod: 'cli_login',
-        defaultModel: 'claude-model',
-        priority: 10,
-        supportsEmbeddings: false,
-        supportsChat: true,
-      },
-      envVars: [],
-      probe: async () => ({ available: true, authenticated: true }),
-    };
     const codexProbe: LlmProviderProbe = {
       descriptor: {
         id: 'codex',
@@ -288,12 +264,12 @@ describe('llm provider discovery', () => {
       probe: async () => ({ available: true, authenticated: true }),
     };
 
-    llmProviderRegistry.register(claudeProbe);
+    llmProviderRegistry.register(claudeCliProbe);
     llmProviderRegistry.register(codexProbe);
 
     const discovered = await discoverLlmProvider({ forceRefresh: true });
     expect(discovered?.provider).toBe('claude');
-    expect(discovered?.modelId).toBe('claude-model');
+    expect(discovered?.modelId).toBe(claudeCliProbe.descriptor.defaultModel);
   });
 
   it('returns null when no providers are available', async () => {

--- a/src/api/bootstrap.ts
+++ b/src/api/bootstrap.ts
@@ -64,7 +64,11 @@ import { storeSCCAnalysis } from '../analysis/deterministic_analysis.js';
 import { buildModuleGraphs } from '../knowledge/module_graph.js';
 import type { IngestionItem } from '../ingest/types.js';
 import { detectLibrarianVersion, upgradeRequired, runUpgrade } from './versioning.js';
-import { resolveLibrarianModelConfigWithDiscovery } from './llm_env.js';
+import {
+  resolveLibrarianModelConfigWithDiscovery,
+  resolveSynthesisAvailability,
+  type SynthesisAvailability,
+} from './llm_env.js';
 import { EmbeddingService } from './embeddings.js';
 import { preloadEmbeddingModel } from './embedding_providers/real_embeddings.js';
 import { generateContextPacks } from './packs.js';
@@ -142,6 +146,7 @@ export interface BootstrapState {
   startedAt: Date | null;
   completedAt: Date | null;
   error?: string;
+  synthesis?: SynthesisAvailability;
 }
 
 interface WorkspaceFingerprint {
@@ -2209,6 +2214,7 @@ export function getBootstrapStatus(workspace: string): BootstrapState {
       progress: 0,
       startedAt: null,
       completedAt: null,
+      synthesis: resolveSynthesisAvailability(),
     }
   );
 }
@@ -2306,6 +2312,7 @@ export async function bootstrapProject(
     maxWallTimeMs,
   };
   const governorRunState = createGovernorRunState();
+  const synthesisAvailability = resolveSynthesisAvailability();
 
   // Initialize state
   const state: BootstrapState = {
@@ -2314,6 +2321,7 @@ export async function bootstrapProject(
     progress: 0,
     startedAt: new Date(),
     completedAt: null,
+    synthesis: synthesisAvailability,
   };
   bootstrapStates.set(workspace, state);
 
@@ -2330,6 +2338,7 @@ export async function bootstrapProject(
     totalContextPacksCreated: 0,
     version: getTargetVersion(config.bootstrapMode === 'full' ? 'full' : 'mvp'),
     success: false,
+    synthesis: synthesisAvailability,
   };
   if (workspaceConfigWarnings.length > 0) {
     report.warnings = report.warnings ?? [];

--- a/src/api/llm_env.ts
+++ b/src/api/llm_env.ts
@@ -4,40 +4,73 @@ import {
   llmProviderRegistry,
   type LibrarianLlmProvider,
 } from './llm_provider_discovery.js';
+import { detectNestedClaudeSession } from './nested_session.js';
+import {
+  hasCodexFallbackSignal,
+  shouldUseAnthropicApiTransport,
+  shouldUseClaudeBrokerTransport,
+} from './llm_transport_env.js';
 
 export type { LibrarianLlmProvider };
 export { llmProviderRegistry };
 
-export function resolveLibrarianProvider(): LibrarianLlmProvider | undefined {
+export interface SynthesisAvailability {
+  synthesisMode: 'llm' | 'structural-only';
+  synthesisUnavailableReason?: string;
+}
+
+export function resolveLibrarianProvider(env: NodeJS.ProcessEnv = process.env): LibrarianLlmProvider | undefined {
   const raw =
-    process.env.LIBRARIAN_LLM_PROVIDER ??
-    process.env.WAVE0_LLM_PROVIDER ??
-    process.env.LLM_PROVIDER;
+    env.LIBRARIAN_LLM_PROVIDER ??
+    env.WAVE0_LLM_PROVIDER ??
+    env.LLM_PROVIDER;
   return raw === 'claude' || raw === 'codex' ? raw : undefined;
 }
 
 export const resolveLiBrainianProvider = resolveLibrarianProvider;
 
-export function resolveLibrarianModelId(provider?: LibrarianLlmProvider): string | undefined {
-  if (process.env.LIBRARIAN_LLM_MODEL) return process.env.LIBRARIAN_LLM_MODEL;
+export function resolveLibrarianModelId(
+  provider?: LibrarianLlmProvider,
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  if (env.LIBRARIAN_LLM_MODEL) return env.LIBRARIAN_LLM_MODEL;
   if (provider === 'claude') {
-    return process.env.CLAUDE_MODEL ?? process.env.WAVE0_LLM_MODEL;
+    return env.CLAUDE_MODEL ?? env.WAVE0_LLM_MODEL;
   }
   if (provider === 'codex') {
-    return process.env.CODEX_MODEL ?? process.env.WAVE0_LLM_MODEL;
+    return env.CODEX_MODEL ?? env.WAVE0_LLM_MODEL;
   }
-  return process.env.CLAUDE_MODEL ?? process.env.CODEX_MODEL ?? process.env.WAVE0_LLM_MODEL;
+  return env.CLAUDE_MODEL ?? env.CODEX_MODEL ?? env.WAVE0_LLM_MODEL;
 }
 
 export const resolveLiBrainianModelId = resolveLibrarianModelId;
 
-export function resolveLibrarianModelConfig(): { provider?: LibrarianLlmProvider; modelId?: string } {
-  const provider = resolveLibrarianProvider();
-  const modelId = resolveLibrarianModelId(provider);
+export function resolveLibrarianModelConfig(
+  env: NodeJS.ProcessEnv = process.env
+): { provider?: LibrarianLlmProvider; modelId?: string } {
+  const provider = resolveLibrarianProvider(env);
+  const modelId = resolveLibrarianModelId(provider, env);
   return { provider, modelId };
 }
 
 export const resolveLiBrainianModelConfig = resolveLibrarianModelConfig;
+
+export function resolveSynthesisAvailability(env: NodeJS.ProcessEnv = process.env): SynthesisAvailability {
+  const nested = detectNestedClaudeSession(env);
+  if (!nested.isNested) {
+    return { synthesisMode: 'llm' };
+  }
+  if (shouldUseAnthropicApiTransport(env) || shouldUseClaudeBrokerTransport(env) || hasCodexFallbackSignal(env)) {
+    return { synthesisMode: 'llm' };
+  }
+  const markers = nested.markers.length > 0 ? nested.markers.join(', ') : 'unknown markers';
+  return {
+    synthesisMode: 'structural-only',
+    synthesisUnavailableReason: `Nested Claude Code session detected (${markers}). Claude CLI is disabled and no alternative LLM transport is configured.`,
+  };
+}
+
+export const resolveLiBrainianSynthesisAvailability = resolveSynthesisAvailability;
 
 export async function resolveLibrarianModelConfigWithDiscovery(): Promise<{
   provider: LibrarianLlmProvider;

--- a/src/api/llm_provider_discovery.ts
+++ b/src/api/llm_provider_discovery.ts
@@ -5,6 +5,12 @@ import os from 'node:os';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { CLI_BINARY_HASHES } from './cli_hash_manifest.js';
+import { detectNestedClaudeSession } from './nested_session.js';
+import {
+  hasEnvValue,
+  shouldUseAnthropicApiTransport,
+  shouldUseClaudeBrokerTransport,
+} from './llm_transport_env.js';
 
 export type LlmAuthMethod = 'cli_login' | 'local' | 'oauth' | 'none' | 'api_key';
 export type LibrarianLlmProvider = 'claude' | 'codex';
@@ -41,25 +47,16 @@ export interface DiscoveredProvider {
   status: LlmProviderProbeResult;
 }
 
-function hasTruthyEnvValue(value: string | undefined): boolean {
-  if (!value) return false;
-  const normalized = value.trim().toLowerCase();
-  return normalized.length > 0 && normalized !== '0' && normalized !== 'false' && normalized !== 'off' && normalized !== 'no';
-}
-
 function resolveHostPreferredProvider(env: NodeJS.ProcessEnv = process.env): LibrarianLlmProvider | null {
   const explicit = env.LIBRARIAN_LLM_PROVIDER;
   if (explicit === 'claude' || explicit === 'codex') {
     return explicit;
   }
 
-  // Nested Claude Code sessions are now supported — the CLI adapter strips
-  // session env vars before spawning, so we no longer force a codex fallback.
-
   const codexHostHints =
-    hasTruthyEnvValue(env.CODEX_HOME)
-    || hasTruthyEnvValue(env.CODEX_PROFILE)
-    || hasTruthyEnvValue(env.CODEX_MODEL);
+    hasEnvValue(env.CODEX_HOME)
+    || hasEnvValue(env.CODEX_PROFILE)
+    || hasEnvValue(env.CODEX_MODEL);
   if (codexHostHints) {
     return 'codex';
   }
@@ -772,6 +769,30 @@ function resolveCodexHome(): string | null {
 
 async function checkClaudeCli(): Promise<LlmProviderProbeResult> {
   try {
+    const nested = detectNestedClaudeSession();
+    if (shouldUseAnthropicApiTransport()) {
+      return {
+        available: true,
+        authenticated: true,
+        metadata: { transport: 'api' },
+      };
+    }
+    if (shouldUseClaudeBrokerTransport()) {
+      return {
+        available: true,
+        authenticated: true,
+        metadata: { transport: 'broker' },
+      };
+    }
+    if (nested.isNested) {
+      const markers = nested.markers.length > 0 ? nested.markers.join(', ') : 'unknown markers';
+      return {
+        available: false,
+        authenticated: false,
+        error: `Nested Claude Code session detected (${markers})`,
+      };
+    }
+
     const version = await runCliCheck('claude', ['--version']);
     if (!version.ok) {
       return {

--- a/src/api/llm_transport_env.ts
+++ b/src/api/llm_transport_env.ts
@@ -1,0 +1,60 @@
+type EnvLike = NodeJS.ProcessEnv | Record<string, string | undefined>;
+
+export type ProviderTransport = 'auto' | 'api' | 'broker' | 'cli';
+
+export function hasEnvValue(value: string | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function parseTransport(value: string | undefined): ProviderTransport {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === 'api' || normalized === 'broker' || normalized === 'cli' || normalized === 'auto') {
+    return normalized;
+  }
+  return 'auto';
+}
+
+export function resolveClaudeTransportMode(env: EnvLike = process.env): ProviderTransport {
+  return parseTransport(env.LIBRARIAN_CLAUDE_TRANSPORT ?? env.LIBRARIAN_LLM_CLAUDE_TRANSPORT);
+}
+
+export function resolveCodexTransportMode(env: EnvLike = process.env): ProviderTransport {
+  return parseTransport(env.LIBRARIAN_CODEX_TRANSPORT ?? env.LIBRARIAN_LLM_CODEX_TRANSPORT);
+}
+
+export function isClaudeBrokerConfigured(env: EnvLike = process.env): boolean {
+  return hasEnvValue(env.LIBRARIAN_CLAUDE_BROKER_URL);
+}
+
+export function shouldUseAnthropicApiTransport(env: EnvLike = process.env): boolean {
+  const mode = resolveClaudeTransportMode(env);
+  if (mode === 'broker') return false;
+  if (mode === 'api') return true;
+  if (mode === 'cli') return false;
+  return hasEnvValue(env.ANTHROPIC_API_KEY);
+}
+
+export function shouldUseClaudeBrokerTransport(env: EnvLike = process.env): boolean {
+  const mode = resolveClaudeTransportMode(env);
+  if (!isClaudeBrokerConfigured(env)) return false;
+  if (mode === 'broker') return true;
+  if (mode === 'api' || mode === 'cli') return false;
+  return true;
+}
+
+export function shouldUseOpenAiApiTransport(env: EnvLike = process.env): boolean {
+  if (!hasEnvValue(env.OPENAI_API_KEY)) return false;
+  const mode = resolveCodexTransportMode(env);
+  if (mode === 'api') return true;
+  if (mode === 'cli') return false;
+  return true;
+}
+
+export function hasCodexFallbackSignal(env: EnvLike = process.env): boolean {
+  const configuredProvider = env.LIBRARIAN_LLM_PROVIDER ?? env.WAVE0_LLM_PROVIDER ?? env.LLM_PROVIDER;
+  return configuredProvider === 'codex'
+    || shouldUseOpenAiApiTransport(env)
+    || hasEnvValue(env.CODEX_HOME)
+    || hasEnvValue(env.CODEX_PROFILE)
+    || hasEnvValue(env.CODEX_MODEL);
+}

--- a/src/api/nested_session.ts
+++ b/src/api/nested_session.ts
@@ -1,0 +1,52 @@
+type EnvLike = NodeJS.ProcessEnv | Record<string, string | undefined>;
+
+const TRUTHY_PATTERN = /^(?!\s*$)(?!0$)(?!false$)(?!off$)(?!no$)/i;
+
+export const CLAUDE_NESTED_SESSION_ENV_VARS: readonly string[] = [
+  'CLAUDE_CODE',
+  'CLAUDECODE',
+  'CLAUDE_CODE_ENTRYPOINT',
+  'CLAUDE_CODE_SESSION',
+  'CLAUDE_CODE_SESSION_ID',
+  'CLAUDE_CODE_MAX_OUTPUT_TOKENS',
+  'CLAUDE_SESSION',
+  'SESSION_ID',
+  'ANTHROPIC_CLAUDE_CODE',
+  'ANTHROPIC_CLAUDE_CODE_SESSION',
+];
+
+function hasTruthyEnvValue(value: string | undefined): boolean {
+  return Boolean(value && TRUTHY_PATTERN.test(value));
+}
+
+export interface NestedClaudeSessionDetection {
+  isNested: boolean;
+  markers: string[];
+}
+
+export function detectNestedClaudeSession(env: EnvLike = process.env): NestedClaudeSessionDetection {
+  const markers: string[] = [];
+  for (const key of CLAUDE_NESTED_SESSION_ENV_VARS) {
+    if (hasTruthyEnvValue(env[key])) {
+      markers.push(key);
+    }
+  }
+
+  if (markers.length === 1 && markers[0] === 'SESSION_ID') {
+    return { isNested: false, markers: [] };
+  }
+
+  if (!markers.includes('SESSION_ID') && hasTruthyEnvValue(env.SESSION_ID) && hasTruthyEnvValue(env.CLAUDE_MODEL)) {
+    markers.push('SESSION_ID');
+  }
+
+  const uniqueMarkers = Array.from(new Set(markers));
+  return { isNested: uniqueMarkers.length > 0, markers: uniqueMarkers };
+}
+
+export function formatNestedSessionReason(env: EnvLike = process.env): string | undefined {
+  const detection = detectNestedClaudeSession(env);
+  if (!detection.isNested) return undefined;
+  const markerList = detection.markers.length > 0 ? detection.markers.join(', ') : 'unknown markers';
+  return `Nested Claude Code session detected (${markerList})`;
+}

--- a/src/cli/commands/__tests__/status.test.ts
+++ b/src/cli/commands/__tests__/status.test.ts
@@ -382,6 +382,45 @@ describe('statusCommand', () => {
     }
   });
 
+  it('reports structural-only synthesis mode when nested Claude session markers are present without an alternate route', async () => {
+    vi.mocked(getWatchState).mockResolvedValue(null);
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.LIBRARIAN_CLAUDE_BROKER_URL;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.LIBRARIAN_LLM_PROVIDER;
+    delete process.env.CODEX_HOME;
+    delete process.env.CODEX_MODEL;
+    delete process.env.CODEX_PROFILE;
+    process.env.CLAUDE_CODE_SESSION = '1';
+
+    try {
+      await statusCommand({ workspace, verbose: false, format: 'json' });
+
+      const output = consoleLogSpy.mock.calls[0]?.[0] as string | undefined;
+      const parsed = JSON.parse(output ?? '{}') as {
+        runtime?: {
+          synthesisMode?: string;
+          synthesisUnavailableReason?: string;
+          unavailableFeatures?: string[];
+        };
+        bootstrap?: {
+          currentRun?: {
+            synthesis?: {
+              synthesisMode?: string;
+              synthesisUnavailableReason?: string;
+            };
+          } | null;
+        };
+      };
+      expect(parsed.runtime?.synthesisMode).toBe('structural-only');
+      expect(parsed.runtime?.synthesisUnavailableReason).toMatch(/nested claude code session/i);
+      expect(parsed.runtime?.unavailableFeatures).toContain('synthesis');
+      expect(parsed.bootstrap?.currentRun).toBeNull();
+    } finally {
+      delete process.env.CLAUDE_CODE_SESSION;
+    }
+  });
+
   it('includes freshness counts in JSON output when git data is available', async () => {
     vi.mocked(getWatchState).mockResolvedValue(null);
     mockStorage.getMetadata.mockResolvedValue({

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -9,6 +9,7 @@ import { getIndexState } from '../../state/index_state.js';
 import { getWatchState } from '../../state/watch_state.js';
 import { deriveWatchHealth } from '../../state/watch_health.js';
 import { checkAllProviders, type AllProviderStatus } from '../../api/provider_check.js';
+import { resolveSynthesisAvailability, type SynthesisAvailability } from '../../api/llm_env.js';
 import { computeEmbeddingCoverage, type EmbeddingCoverageSummary } from '../../api/embedding_coverage.js';
 import { inspectWorkspaceLocks } from '../../storage/storage_recovery.js';
 import type { LiBrainianStorage } from '../../storage/types.js';
@@ -58,6 +59,8 @@ type StatusReport = {
     offlineMode: boolean;
     availableFeatures: string[];
     unavailableFeatures: string[];
+    synthesisMode?: 'llm' | 'structural-only';
+    synthesisUnavailableReason?: string;
   };
   storage: { status: 'ready' | 'degraded' | 'not_initialized'; reason?: string };
   schema?: {
@@ -81,6 +84,7 @@ type StatusReport = {
       progress: number;
       startedAt: string | null;
       completedAt: string | null;
+      synthesis?: SynthesisAvailability;
     } | null;
   };
   index?: {
@@ -243,9 +247,18 @@ export async function statusCommand(options: StatusCommandOptions): Promise<numb
     availableFeatures: ['search', 'graph', 'symbols'],
     unavailableFeatures: [],
   };
-  if (runtime.offlineMode) {
-    runtime.unavailableFeatures = ['synthesis', 'llm_enrichment'];
+  const synthesisStatus = resolveSynthesisAvailability();
+  runtime.synthesisMode = synthesisStatus.synthesisMode;
+  if (synthesisStatus.synthesisUnavailableReason) {
+    runtime.synthesisUnavailableReason = synthesisStatus.synthesisUnavailableReason;
   }
+  if (synthesisStatus.synthesisMode === 'structural-only') {
+    runtime.unavailableFeatures.push('synthesis', 'llm_enrichment');
+  }
+  if (runtime.offlineMode) {
+    runtime.unavailableFeatures.push('synthesis', 'llm_enrichment');
+  }
+  runtime.unavailableFeatures = Array.from(new Set(runtime.unavailableFeatures));
 
   const report: StatusReport = {
     workspace: workspaceRoot,
@@ -269,6 +282,8 @@ export async function statusCommand(options: StatusCommandOptions): Promise<numb
       { key: 'Offline Mode', value: runtime.offlineMode },
       { key: 'Available Features', value: runtime.availableFeatures.join(', ') || 'none' },
       { key: 'Unavailable Features', value: runtime.unavailableFeatures.join(', ') || 'none' },
+      { key: 'Synthesis Mode', value: runtime.synthesisMode ?? 'llm' },
+      { key: 'Synthesis Reason', value: runtime.synthesisUnavailableReason ?? 'llm available' },
     ]);
     console.log();
 
@@ -357,6 +372,7 @@ export async function statusCommand(options: StatusCommandOptions): Promise<numb
             progress: bootstrapState.progress,
             startedAt: bootstrapState.startedAt?.toISOString() ?? null,
             completedAt: bootstrapState.completedAt?.toISOString() ?? null,
+            synthesis: bootstrapState.synthesis,
           }
         : null,
     };
@@ -401,6 +417,15 @@ export async function statusCommand(options: StatusCommandOptions): Promise<numb
           { key: 'Started At', value: formatTimestamp(bootstrapState.startedAt) },
           { key: 'Completed At', value: formatTimestamp(bootstrapState.completedAt) },
         ]);
+        if (bootstrapState.synthesis) {
+          printKeyValue([
+            { key: 'Synthesis Mode', value: bootstrapState.synthesis.synthesisMode },
+            {
+              key: 'Synthesis Reason',
+              value: bootstrapState.synthesis.synthesisUnavailableReason ?? 'llm available',
+            },
+          ]);
+        }
       }
       console.log();
 

--- a/src/migrations/001_initial.sql
+++ b/src/migrations/001_initial.sql
@@ -127,5 +127,6 @@ CREATE TABLE IF NOT EXISTS librarian_bootstrap_history (
   total_context_packs INTEGER NOT NULL,
   version_string TEXT NOT NULL,
   success INTEGER NOT NULL,
-  error TEXT
+  error TEXT,
+  synthesis TEXT
 );

--- a/src/storage/__tests__/bootstrap_history.test.ts
+++ b/src/storage/__tests__/bootstrap_history.test.ts
@@ -1,0 +1,60 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { BootstrapReport } from '../../types.js';
+import { createSqliteStorage } from '../sqlite_storage.js';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (!dir) continue;
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe('bootstrap history persistence', () => {
+  it('stores synthesis availability metadata alongside bootstrap reports', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'bootstrap-history-'));
+    tempDirs.push(dir);
+    const dbPath = path.join(dir, 'librarian.sqlite');
+    const storage = createSqliteStorage(dbPath, dir);
+    await storage.initialize();
+
+    const synthesis = {
+      synthesisMode: 'structural-only' as const,
+      synthesisUnavailableReason: 'Nested Claude session',
+    };
+    const now = new Date();
+    const report: BootstrapReport = {
+      workspace: dir,
+      startedAt: now,
+      completedAt: now,
+      phases: [],
+      totalFilesProcessed: 0,
+      totalFunctionsIndexed: 0,
+      totalContextPacksCreated: 0,
+      version: {
+        major: 0,
+        minor: 0,
+        patch: 0,
+        string: '0.0.0-test',
+        qualityTier: 'mvp',
+        indexedAt: now,
+        indexerVersion: '0.0.0-test',
+        features: [],
+      },
+      success: true,
+      synthesis,
+    };
+
+    await storage.recordBootstrapReport(report);
+    const stored = await storage.getLastBootstrapReport();
+
+    expect(stored?.synthesis).toEqual(synthesis);
+
+    await storage.close();
+  });
+});

--- a/src/storage/sqlite_storage.ts
+++ b/src/storage/sqlite_storage.ts
@@ -717,6 +717,7 @@ export class SqliteLiBrainianStorage implements LiBrainianStorage {
           workspaceRoot: this.workspaceRoot,
           dbPath: this.dbPath,
         });
+        this.ensureBootstrapHistoryColumns();
         this.ensureEmbeddingColumns();
         this.ensureGraphTables();
         this.ensureTemporalTables();
@@ -1078,6 +1079,15 @@ export class SqliteLiBrainianStorage implements LiBrainianStorage {
       this.db
         .prepare('ALTER TABLE librarian_embeddings ADD COLUMN token_count INTEGER NOT NULL DEFAULT 0')
         .run();
+    }
+  }
+
+  private ensureBootstrapHistoryColumns(): void {
+    if (!this.db || !this.hasTable('librarian_bootstrap_history')) return;
+    const columns = this.db.prepare('PRAGMA table_info(librarian_bootstrap_history)').all() as { name: string }[];
+    const names = new Set(columns.map((column) => column.name));
+    if (!names.has('synthesis')) {
+      this.db.prepare('ALTER TABLE librarian_bootstrap_history ADD COLUMN synthesis TEXT').run();
     }
   }
 
@@ -5420,8 +5430,8 @@ export class SqliteLiBrainianStorage implements LiBrainianStorage {
     db.prepare(`
       INSERT INTO librarian_bootstrap_history (
         id, workspace, started_at, completed_at, phases, total_files,
-        total_functions, total_context_packs, version_string, success, error
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        total_functions, total_context_packs, version_string, success, error, synthesis
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       randomUUID(),
       report.workspace,
@@ -5433,7 +5443,8 @@ export class SqliteLiBrainianStorage implements LiBrainianStorage {
       report.totalContextPacksCreated,
       report.version.string,
       report.success ? 1 : 0,
-      report.error || null
+      report.error || null,
+      report.synthesis ? JSON.stringify(report.synthesis) : null
     );
   }
 
@@ -8438,6 +8449,7 @@ interface BootstrapHistoryRow {
   version_string: string;
   success: number;
   error: string | null;
+  synthesis: string | null;
 }
 
 interface TestMappingRow {
@@ -8817,7 +8829,15 @@ function rowToBootstrapReport(row: BootstrapHistoryRow): BootstrapReport {
     version: parseVersionString(row.version_string),
     success: row.success === 1,
     error: row.error || undefined,
+    synthesis: parseBootstrapSynthesis(row.synthesis),
   };
+}
+
+function parseBootstrapSynthesis(serialized: string | null): BootstrapReport['synthesis'] {
+  if (!serialized) return undefined;
+  const parsed = safeJsonParse<BootstrapReport['synthesis']>(serialized);
+  if (!parsed.ok) return undefined;
+  return parsed.value ?? undefined;
 }
 
 function parseVersionString(versionString: string): LiBrainianVersion {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { EmbeddingProvider, EmbeddingService } from './api/embeddings.js';
+import type { SynthesisAvailability } from './api/llm_env.js';
 import type { AdequacyReport } from './api/difficulty_detectors.js';
 import type { EvidenceRef } from './api/evidence.js';
 import type { TechniqueOperatorType } from './strategic/techniques.js';
@@ -623,6 +624,8 @@ export interface BootstrapReport {
   };
   /** Bootstrap-time repository orientation persisted to .librarian/CODEBASE_BRIEFING.md */
   codebaseBriefing?: BootstrapBriefingSummary;
+  /** Availability of LLM synthesis during bootstrap */
+  synthesis?: SynthesisAvailability;
 }
 
 export interface BootstrapPhaseMetrics {


### PR DESCRIPTION
## Summary
- block only Claude CLI transport in nested Claude Code sessions while preserving Codex and Claude API/broker LLM paths
- surface synthesis availability consistently through bootstrap history and status output
- add regression coverage for nested-session provider discovery, status reporting, and bootstrap persistence

## Verification
- npm run build
- npm test -- --run
- npm test -- --run src/constructions/processes/__tests__/context_pack_depth_gate.test.ts src/constructions/processes/__tests__/hallucinated_api_detector.test.ts src/api/__tests__/llm_provider_discovery.test.ts src/__tests__/adapters/cli_llm_service.test.ts src/api/__tests__/llm_env.test.ts src/api/__tests__/bootstrap_status.test.ts src/cli/commands/__tests__/status.test.ts src/storage/__tests__/bootstrap_history.test.ts
- LIBRARIAN_LLM_PROVIDER=codex ./ask --json "How does nested session detection work?"
- LIBRARIAN_LLM_PROVIDER=codex node scripts/issue-quality-analysis.mjs 905 --description "nested-session detection and non-CLI fallback preservation" --queries "How does nested session detection work?" --queries "How does provider selection fall back in nested Claude Code sessions?" --verdict improved --assessment "Nested Claude sessions no- LIBRARIAN_LLM_PROVIDER=codex node scripts/issue-quality-analysis.mjs 905 --description "nested-session  live nested-session query synthesizes an answer from src/api/nested_session.ts instead of collapsing to structural-only due to provider shutdown." --concerns "Lower-ranked retrieval results still include some unrelated noise and semantic retrieval reports brute-force fallback, so retrieval quality is improved enough for this issue but not fully clean."

Closes #905