### PR TITLE
fix: align status and doctor health summaries

### DIFF
--- a/src/cli/commands/__tests__/doctor.test.ts
+++ b/src/cli/commands/__tests__/doctor.test.ts
@@ -212,6 +212,43 @@ describe('doctorCommand', () => {
     expect(dbCheck.status).toBe('OK');
   });
 
+  it('elevates overall status when cross-db consistency is critical', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-cross-db-'));
+    const activeDbPath = path.join(tempRoot, '.librarian', 'librarian.sqlite');
+    const legacyDbPath = path.join(tempRoot, '.librarian', 'knowledge.db');
+
+    try {
+      fs.mkdirSync(path.dirname(activeDbPath), { recursive: true });
+      fs.writeFileSync(activeDbPath, '');
+      fs.writeFileSync(legacyDbPath, '');
+      const now = new Date();
+      const older = new Date(now.getTime() - 10_000);
+      fs.utimesSync(activeDbPath, older, older);
+      fs.utimesSync(legacyDbPath, now, now);
+
+      vi.mocked(resolveDbPath).mockResolvedValue(activeDbPath);
+      vi.mocked(resolveWorkspaceRoot).mockReturnValue({
+        original: tempRoot,
+        workspace: tempRoot,
+        changed: false,
+        sourceFileCount: 0,
+        reason: 'no_candidate',
+      });
+
+      await doctorCommand({ workspace: tempRoot, json: true });
+
+      const report = parseJsonReport(consoleLogSpy);
+      expect(report.overallStatus).toBe('ERROR');
+      expect(report.checks).toContainEqual(expect.objectContaining({
+        name: 'Cross-DB Consistency',
+        status: 'ERROR',
+        message: 'Legacy DB files are newer than active store (1 files)',
+      }));
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it('releases storage handles when DB-backed checks throw after initialize', async () => {
     const storages: Array<{
       initialize: Mock;

--- a/src/cli/commands/__tests__/status.test.ts
+++ b/src/cli/commands/__tests__/status.test.ts
@@ -95,7 +95,7 @@ describe('statusCommand', () => {
         totalFunctions: 1,
         totalModules: 1,
         totalContextPacks: 1,
-        totalEmbeddings: 0,
+        totalEmbeddings: 1,
         storageSizeBytes: 10,
         averageConfidence: 0.5,
         cacheHitRate: 0.1,
@@ -214,6 +214,15 @@ describe('statusCommand', () => {
 
   it('emits JSON when format is json', async () => {
     vi.mocked(getWatchState).mockResolvedValue(null);
+    mockStorage.getStats.mockResolvedValue({
+      totalFunctions: 1,
+      totalModules: 1,
+      totalContextPacks: 1,
+      totalEmbeddings: 0,
+      storageSizeBytes: 10,
+      averageConfidence: 0.5,
+      cacheHitRate: 0.1,
+    });
     mockStorage.getFunctions.mockResolvedValue([
       { filePath: `${workspace}/src/main.ts` },
       { filePath: `${workspace}/src/helpers.ts` },
@@ -250,7 +259,7 @@ describe('statusCommand', () => {
     expect(parsed.provenance?.status).toBeDefined();
     expect(parsed.server?.status).toBeDefined();
     expect(parsed.config?.status).toBeDefined();
-    expect(exitCode).toBe(0);
+    expect(exitCode).toBe(1);
   });
 
   it('marks storage as degraded when active lock pids are present', async () => {
@@ -563,5 +572,85 @@ describe('statusCommand', () => {
 
     const exitCode = await statusCommand({ workspace, verbose: false, format: 'json' });
     expect(exitCode).toBe(2);
+  });
+
+  it('surfaces doctor critical failures in status output and exit code', async () => {
+    vi.mocked(getWatchState).mockResolvedValue(null);
+    vi.mocked(checkAllProviders).mockResolvedValue({
+      llm: { available: true, provider: 'claude', model: 'test-model', latencyMs: 120 },
+      embedding: {
+        available: false,
+        provider: 'xenova',
+        model: 'test-embed',
+        latencyMs: 50,
+        error: 'missing model',
+      },
+    });
+
+    const exitCode = await statusCommand({ workspace, verbose: false, format: 'json' });
+
+    const output = consoleLogSpy.mock.calls[0]?.[0] as string | undefined;
+    const parsed = JSON.parse(output ?? '{}') as {
+      healthSummary?: {
+        status?: string;
+        summary?: { errors?: number };
+        checks?: Array<{ name?: string; status?: string; message?: string }>;
+      };
+    };
+    expect(parsed.healthSummary?.status).toBe('ERROR');
+    expect(parsed.healthSummary?.summary?.errors).toBe(1);
+    expect(parsed.healthSummary?.checks).toContainEqual(expect.objectContaining({
+      name: 'Embedding Provider',
+      status: 'ERROR',
+      message: 'Embedding provider unavailable: missing model',
+    }));
+    expect(exitCode).toBe(1);
+  });
+
+  it('surfaces cross-db consistency failures in status output and exit code', async () => {
+    vi.mocked(getWatchState).mockResolvedValue(null);
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'status-cross-db-'));
+    const activeDbPath = path.join(tempRoot, '.librarian', 'librarian.sqlite');
+    const legacyDbPath = path.join(tempRoot, '.librarian', 'knowledge.db');
+
+    try {
+      await fs.mkdir(path.dirname(activeDbPath), { recursive: true });
+      await fs.writeFile(activeDbPath, '', 'utf8');
+      await fs.writeFile(legacyDbPath, '', 'utf8');
+      const now = new Date();
+      const older = new Date(now.getTime() - 10_000);
+      await fs.utimes(activeDbPath, older, older);
+      await fs.utimes(legacyDbPath, now, now);
+
+      vi.mocked(resolveDbPath).mockResolvedValue(activeDbPath);
+      vi.mocked(resolveWorkspaceRoot).mockReturnValue({
+        original: tempRoot,
+        workspace: tempRoot,
+        changed: false,
+        sourceFileCount: 0,
+        reason: 'no_candidate',
+      });
+
+      const exitCode = await statusCommand({ workspace: tempRoot, verbose: false, format: 'json' });
+
+      const output = consoleLogSpy.mock.calls[0]?.[0] as string | undefined;
+      const parsed = JSON.parse(output ?? '{}') as {
+        healthSummary?: {
+          status?: string;
+          summary?: { errors?: number };
+          checks?: Array<{ name?: string; status?: string; message?: string }>;
+        };
+      };
+      expect(parsed.healthSummary?.status).toBe('ERROR');
+      expect(parsed.healthSummary?.summary?.errors).toBe(1);
+      expect(parsed.healthSummary?.checks).toContainEqual(expect.objectContaining({
+        name: 'Cross-DB Consistency',
+        status: 'ERROR',
+        message: 'Legacy DB files are newer than active store (1 files)',
+      }));
+      expect(exitCode).toBe(1);
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/src/cli/commands/cross_db_consistency.ts
+++ b/src/cli/commands/cross_db_consistency.ts
@@ -1,0 +1,86 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import type { HealthCheckStatus } from './health_summary.js';
+
+export const CROSS_DB_CONSISTENCY_CHECK_NAME = 'Cross-DB Consistency';
+
+const LEGACY_DB_FILENAMES = [
+  'knowledge.db',
+  'evidence_ledger.db',
+  'librarian.db',
+] as const;
+
+export interface CrossDbConsistencyDetails extends Record<string, unknown> {
+  activeDb: string;
+  legacyFiles: string[];
+  legacyCount: number;
+}
+
+export interface CrossDbConsistencyResult {
+  status: HealthCheckStatus;
+  message: string;
+  details: CrossDbConsistencyDetails;
+  suggestion?: string;
+}
+
+async function statMtimeMs(filePath: string): Promise<number | null> {
+  try {
+    const stats = await fs.stat(filePath);
+    return stats.mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+export async function evaluateCrossDbConsistency(
+  workspace: string,
+  dbPath: string,
+): Promise<CrossDbConsistencyResult> {
+  const librarianDir = path.join(workspace, '.librarian');
+  const activeDb = path.resolve(dbPath);
+  const legacyCandidates = LEGACY_DB_FILENAMES.map((filename) => path.join(librarianDir, filename));
+
+  const legacyFiles = (
+    await Promise.all(
+      legacyCandidates.map(async (candidate) => {
+        const mtimeMs = await statMtimeMs(candidate);
+        if (mtimeMs == null || path.resolve(candidate) === activeDb) return null;
+        return { path: candidate, mtimeMs };
+      }),
+    )
+  ).filter((entry): entry is { path: string; mtimeMs: number } => entry !== null);
+
+  const details: CrossDbConsistencyDetails = {
+    activeDb,
+    legacyFiles: legacyFiles.map((entry) => entry.path),
+    legacyCount: legacyFiles.length,
+  };
+
+  if (legacyFiles.length === 0) {
+    return {
+      status: 'OK',
+      message: 'No legacy DB divergence artifacts detected',
+      details,
+    };
+  }
+
+  const newestLegacyMs = legacyFiles.reduce((max, entry) => Math.max(max, entry.mtimeMs), 0);
+  const activeMtimeMs = (await statMtimeMs(activeDb)) ?? 0;
+
+  if (newestLegacyMs > activeMtimeMs + 1_000) {
+    return {
+      status: 'ERROR',
+      message: `Legacy DB files are newer than active store (${legacyFiles.length} files)`,
+      details,
+      suggestion: 'Run `librarian bootstrap --force` to rebuild and converge into .librarian/librarian.sqlite',
+    };
+  }
+
+  return {
+    status: 'WARNING',
+    message: `Legacy DB artifacts detected (${legacyFiles.length} files)`,
+    details,
+    suggestion: 'Remove stale legacy DB files after verifying current index health',
+  };
+}

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -32,6 +32,8 @@ import type { LibrarianStorage } from '../../storage/types.js';
 import { resolveWorkspaceRoot } from '../../utils/workspace_resolver.js';
 import { inspectWorkspaceLocks } from '../../storage/storage_recovery.js';
 import { getSessionState } from '../../memory/session_store.js';
+import { CROSS_DB_CONSISTENCY_CHECK_NAME, evaluateCrossDbConsistency } from './cross_db_consistency.js';
+import { summarizeSharedHealthChecks } from './health_summary.js';
 
 // ============================================================================
 // TYPES
@@ -82,6 +84,13 @@ export interface DoctorCommandOptions {
   installGrammars?: boolean;
   riskTolerance?: 'safe' | 'low' | 'medium';
 }
+
+export type DoctorDiagnosticsOptions = Pick<
+  DoctorCommandOptions,
+  'workspace' | 'heal' | 'fix' | 'checkConsistency' | 'installGrammars' | 'riskTolerance' | 'json'
+> & {
+  workspaceOriginal?: string;
+};
 
 interface ActionTemplate {
   command: string;
@@ -1063,56 +1072,17 @@ async function checkCrossDbConsistency(
   dbPath: string
 ): Promise<DiagnosticCheck> {
   const check: DiagnosticCheck = {
-    name: 'Cross-DB Consistency',
+    name: CROSS_DB_CONSISTENCY_CHECK_NAME,
     status: 'OK',
     message: '',
   };
 
   try {
-    const librarianDir = path.join(workspace, '.librarian');
-    const legacyCandidates = [
-      path.join(librarianDir, 'knowledge.db'),
-      path.join(librarianDir, 'evidence_ledger.db'),
-      path.join(librarianDir, 'librarian.db'),
-    ];
-
-    const activeDb = path.resolve(dbPath);
-    const legacyFiles = legacyCandidates.filter((candidate) => {
-      if (!fs.existsSync(candidate)) return false;
-      return path.resolve(candidate) !== activeDb;
-    });
-
-    check.details = {
-      activeDb,
-      legacyFiles,
-      legacyCount: legacyFiles.length,
-    };
-
-    if (legacyFiles.length === 0) {
-      check.message = 'No legacy DB divergence artifacts detected';
-      return check;
-    }
-
-    let newestLegacyMs = 0;
-    for (const legacyFile of legacyFiles) {
-      try {
-        newestLegacyMs = Math.max(newestLegacyMs, fs.statSync(legacyFile).mtimeMs);
-      } catch {
-        // Ignore stat failures; existence already confirmed.
-      }
-    }
-    const activeMtimeMs = fs.existsSync(activeDb) ? fs.statSync(activeDb).mtimeMs : 0;
-
-    if (newestLegacyMs > activeMtimeMs + 1_000) {
-      check.status = 'ERROR';
-      check.message = `Legacy DB files are newer than active store (${legacyFiles.length} files)`;
-      check.suggestion = 'Run `librarian bootstrap --force` to rebuild and converge into .librarian/librarian.sqlite';
-      return check;
-    }
-
-    check.status = 'WARNING';
-    check.message = `Legacy DB artifacts detected (${legacyFiles.length} files)`;
-    check.suggestion = 'Remove stale legacy DB files after verifying current index health';
+    const result = await evaluateCrossDbConsistency(workspace, dbPath);
+    check.status = result.status;
+    check.message = result.message;
+    check.details = result.details;
+    check.suggestion = result.suggestion;
     return check;
   } catch (error) {
     check.status = 'ERROR';
@@ -1974,35 +1944,25 @@ async function runEmbeddingIntegrityFix(
 // MAIN DOCTOR COMMAND
 // ============================================================================
 
-export async function doctorCommand(options: DoctorCommandOptions): Promise<void> {
+export async function generateDoctorReport(options: DoctorDiagnosticsOptions): Promise<DoctorReport> {
   const {
     workspace,
-    verbose = false,
-    json = false,
+    workspaceOriginal,
     heal = false,
     fix = false,
     checkConsistency = false,
     installGrammars = false,
     riskTolerance = 'low',
+    json = false,
   } = options;
 
-  let workspaceRoot = path.resolve(workspace);
-  if (process.env.LIBRARIAN_DISABLE_WORKSPACE_AUTODETECT !== '1') {
-    const resolution = resolveWorkspaceRoot(workspaceRoot);
-    if (resolution.changed) {
-      workspaceRoot = resolution.workspace;
-      if (!json) {
-        const detail = resolution.marker ? `marker ${resolution.marker}` : (resolution.reason ?? 'source discovery');
-        console.log(`Auto-detected project root at ${workspaceRoot} (${detail}). Using it.\n`);
-      }
-    }
-  }
+  const workspaceRoot = path.resolve(workspace);
 
   const report: DoctorReport = {
     timestamp: new Date().toISOString(),
     version: LIBRARIAN_VERSION.string,
     workspace: workspaceRoot,
-    workspaceOriginal: workspaceRoot !== workspace ? workspace : undefined,
+    workspaceOriginal: workspaceOriginal && workspaceOriginal !== workspaceRoot ? workspaceOriginal : undefined,
     overallStatus: 'OK',
     checks: [],
     actions: [],
@@ -2030,14 +1990,7 @@ export async function doctorCommand(options: DoctorCommandOptions): Promise<void
     report.summary.errors = 1;
     report.actions = buildDoctorActions(report.checks);
     report.overallStatus = 'ERROR';
-
-    if (json) {
-      console.log(JSON.stringify(report, null, 2));
-    } else {
-      outputTextReport(report, verbose);
-    }
-    process.exitCode = 1;
-    return;
+    return report;
   }
 
   const healChecks: DiagnosticCheck[] = [];
@@ -2211,21 +2164,53 @@ export async function doctorCommand(options: DoctorCommandOptions): Promise<void
   }
 
   // Determine overall status
-  if (report.summary.errors > 0) {
-    report.overallStatus = 'ERROR';
-  } else if (report.summary.warnings > 0) {
-    report.overallStatus = 'WARNING';
-  }
+  report.overallStatus = summarizeSharedHealthChecks(report.checks, { generatedAt: report.timestamp }).status;
   report.actions = buildDoctorActions(report.checks);
 
-  // Output report
+  return report;
+}
+
+export async function doctorCommand(options: DoctorCommandOptions): Promise<void> {
+  const {
+    workspace,
+    verbose = false,
+    json = false,
+    heal = false,
+    fix = false,
+    checkConsistency = false,
+    installGrammars = false,
+    riskTolerance = 'low',
+  } = options;
+
+  let workspaceRoot = path.resolve(workspace);
+  if (process.env.LIBRARIAN_DISABLE_WORKSPACE_AUTODETECT !== '1') {
+    const resolution = resolveWorkspaceRoot(workspaceRoot);
+    if (resolution.changed) {
+      workspaceRoot = resolution.workspace;
+      if (!json) {
+        const detail = resolution.marker ? `marker ${resolution.marker}` : (resolution.reason ?? 'source discovery');
+        console.log(`Auto-detected project root at ${workspaceRoot} (${detail}). Using it.\n`);
+      }
+    }
+  }
+
+  const report = await generateDoctorReport({
+    workspace: workspaceRoot,
+    workspaceOriginal: workspaceRoot !== workspace ? workspace : undefined,
+    heal,
+    fix,
+    checkConsistency,
+    installGrammars,
+    riskTolerance,
+    json,
+  });
+
   if (json) {
     console.log(JSON.stringify(report, null, 2));
   } else {
     outputTextReport(report, verbose);
   }
 
-  // Set exit code based on overall status
   if (report.overallStatus === 'ERROR') {
     process.exitCode = 1;
   }

--- a/src/cli/commands/health_summary.ts
+++ b/src/cli/commands/health_summary.ts
@@ -1,0 +1,66 @@
+export type HealthCheckStatus = 'OK' | 'WARNING' | 'ERROR';
+
+export interface HealthCheck {
+  name: string;
+  status: HealthCheckStatus;
+  message: string;
+  suggestion?: string;
+}
+
+export interface SharedHealthSummary {
+  status: HealthCheckStatus;
+  summary: {
+    total: number;
+    ok: number;
+    warnings: number;
+    errors: number;
+  };
+  checks: HealthCheck[];
+  generatedAt: string;
+}
+
+const READINESS_CHECK_NAMES = new Set([
+  'Database Path Resolution',
+  'Database Access',
+  'Bootstrap Status',
+  'Index Freshness',
+  'Watch Freshness',
+  'Lock File Staleness',
+  'Functions/Embeddings Correlation',
+  'Cross-DB Consistency',
+  'Modules Indexed',
+  'Context Packs Health',
+  'Knowledge Confidence',
+  'Embedding Provider',
+  'LLM Provider',
+]);
+
+export function summarizeSharedHealthChecks(
+  checks: HealthCheck[],
+  options: { generatedAt?: string; includePassingChecks?: boolean } = {},
+): SharedHealthSummary {
+  const readinessChecks = checks.filter((check) => READINESS_CHECK_NAMES.has(check.name));
+  const summary = {
+    total: readinessChecks.length,
+    ok: 0,
+    warnings: 0,
+    errors: 0,
+  };
+
+  for (const check of readinessChecks) {
+    if (check.status === 'ERROR') summary.errors += 1;
+    else if (check.status === 'WARNING') summary.warnings += 1;
+    else summary.ok += 1;
+  }
+
+  const filteredChecks = options.includePassingChecks
+    ? readinessChecks
+    : readinessChecks.filter((check) => check.status !== 'OK');
+
+  return {
+    status: summary.errors > 0 ? 'ERROR' : (summary.warnings > 0 ? 'WARNING' : 'OK'),
+    summary,
+    checks: filteredChecks,
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+  };
+}

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -30,6 +30,8 @@ import {
   readWorkspaceSetState,
   type WorkspaceSetPackageStatus,
 } from '../workspace_set.js';
+import { CROSS_DB_CONSISTENCY_CHECK_NAME, evaluateCrossDbConsistency } from './cross_db_consistency.js';
+import { summarizeSharedHealthChecks, type HealthCheck, type HealthCheckStatus, type SharedHealthSummary } from './health_summary.js';
 
 export interface StatusCommandOptions {
   workspace: string;
@@ -139,6 +141,7 @@ type StatusReport = {
     status: AllProviderStatus | null;
     error?: string;
   };
+  healthSummary?: SharedHealthSummary | null;
   freshness?: {
     totalIndexedFiles: number;
     freshFiles: number;
@@ -624,6 +627,7 @@ export async function statusCommand(options: StatusCommandOptions): Promise<numb
         error: error instanceof Error ? error.message : 'Unable to check providers',
       };
     }
+    report.healthSummary = await buildStatusHealthSummary(report, workspaceRoot, resolvedDbPath);
 
     if (costArgs.includeCosts) {
       try {
@@ -721,6 +725,27 @@ export async function statusCommand(options: StatusCommandOptions): Promise<numb
       printKeyValue([{ key: 'Status', value: 'Unable to check providers' }]);
     }
     console.log();
+
+    if (report.healthSummary) {
+      console.log('System Health:');
+      printKeyValue([
+        { key: 'Overall Status', value: report.healthSummary.status },
+        { key: 'Generated At', value: report.healthSummary.generatedAt },
+        { key: 'Total Checks', value: report.healthSummary.summary.total },
+        { key: 'Errors', value: report.healthSummary.summary.errors },
+        { key: 'Warnings', value: report.healthSummary.summary.warnings },
+      ]);
+      if (report.healthSummary.checks.length > 0) {
+        console.log('\nTop Doctor Findings:');
+        for (const check of report.healthSummary.checks) {
+          console.log(`  - ${check.name}: ${check.status} - ${check.message}`);
+          if (check.suggestion) {
+            console.log(`    Suggestion: ${check.suggestion}`);
+          }
+        }
+      }
+      console.log();
+    }
 
     if (costArgs.includeCosts) {
       console.log('Cost Telemetry:');
@@ -881,10 +906,365 @@ async function statusWorkspaceSet(options: {
 
 function deriveStatusExitCode(report: StatusReport): number {
   if (report.storage.status === 'not_initialized') return 2;
-  if (report.storage.status === 'degraded') return 1;
-  if (report.bootstrap?.required.full) return 1;
-  if (report.watch?.health?.suspectedDead) return 1;
+  if (report.healthSummary?.status === 'ERROR') return 1;
   return 0;
+}
+
+async function buildStatusHealthSummary(
+  report: StatusReport,
+  workspaceRoot: string,
+  resolvedDbPath: string | null,
+): Promise<SharedHealthSummary> {
+  return summarizeSharedHealthChecks(
+    await collectStatusHealthChecks(report, workspaceRoot, resolvedDbPath),
+    { includePassingChecks: false },
+  );
+}
+
+async function collectStatusHealthChecks(
+  report: StatusReport,
+  workspaceRoot: string,
+  resolvedDbPath: string | null,
+): Promise<HealthCheck[]> {
+  const checks: HealthCheck[] = [];
+
+  checks.push(createStorageHealthCheck(report));
+  if (report.bootstrap) {
+    checks.push({
+      name: 'Bootstrap Status',
+      status: report.bootstrap.required.mvp ? 'WARNING' : 'OK',
+      message: report.bootstrap.required.mvp
+        ? `Bootstrap outdated: ${report.bootstrap.reasons.mvp}`
+        : 'Bootstrap complete and up-to-date',
+      suggestion: report.bootstrap.required.mvp ? 'Run `librarian bootstrap` to refresh' : undefined,
+    });
+  }
+  checks.push(createIndexFreshnessHealthCheck(report));
+  checks.push(createWatchHealthCheck(report));
+  checks.push(createLockHealthCheck(report));
+  if (resolvedDbPath && report.storage.status === 'ready') {
+    checks.push(await createCrossDbConsistencyHealthCheck(workspaceRoot, resolvedDbPath));
+  }
+  if (report.stats) {
+    checks.push(createEmbeddingCoverageHealthCheck(report));
+    checks.push(createModulesHealthCheck(report));
+    checks.push(createContextPackHealthCheck(report));
+    checks.push(createConfidenceHealthCheck(report));
+  }
+  checks.push(createEmbeddingProviderHealthCheck(report));
+  checks.push(createLlmProviderHealthCheck(report));
+
+  return checks;
+}
+
+async function createCrossDbConsistencyHealthCheck(
+  workspaceRoot: string,
+  dbPath: string,
+): Promise<HealthCheck> {
+  try {
+    const result = await evaluateCrossDbConsistency(workspaceRoot, dbPath);
+    return {
+      name: CROSS_DB_CONSISTENCY_CHECK_NAME,
+      status: result.status,
+      message: result.message,
+      suggestion: result.suggestion,
+    };
+  } catch (error) {
+    return {
+      name: CROSS_DB_CONSISTENCY_CHECK_NAME,
+      status: 'ERROR',
+      message: `Failed to inspect cross-DB consistency: ${error instanceof Error ? error.message : String(error)}`,
+      suggestion: 'Run `librarian bootstrap --force` to rebuild a single active database',
+    };
+  }
+}
+
+function createStorageHealthCheck(report: StatusReport): HealthCheck {
+  if (report.storage.status === 'ready') {
+    return {
+      name: 'Database Access',
+      status: 'OK',
+      message: 'Database accessible',
+    };
+  }
+  if (report.storage.status === 'degraded') {
+    return {
+      name: 'Database Access',
+      status: 'ERROR',
+      message: `Database degraded: ${report.storage.reason ?? 'storage health degraded'}`,
+      suggestion: 'Run `librarian doctor --heal` or wait for active locks to clear.',
+    };
+  }
+  return {
+    name: 'Database Access',
+    status: 'ERROR',
+    message: `Database unavailable: ${report.storage.reason ?? 'not initialized'}`,
+    suggestion: 'Run `librarian bootstrap --force` to initialize the active store.',
+  };
+}
+
+function createIndexFreshnessHealthCheck(report: StatusReport): HealthCheck {
+  const lastFullIndex = report.index?.lastFullIndex ?? report.metadata?.lastIndexing ?? null;
+  if (!lastFullIndex) {
+    return {
+      name: 'Index Freshness',
+      status: 'WARNING',
+      message: 'Missing last-index timestamp',
+      suggestion: 'Run `librarian bootstrap --force` to create a fresh index baseline',
+    };
+  }
+  return {
+    name: 'Index Freshness',
+    status: 'OK',
+    message: 'Index freshness baseline present',
+  };
+}
+
+function createWatchHealthCheck(report: StatusReport): HealthCheck {
+  const health = report.watch?.health;
+  const watchState = report.watch?.state as { needs_catchup?: boolean; last_error?: string } | null | undefined;
+  if (!health && !watchState) {
+    return {
+      name: 'Watch Freshness',
+      status: 'WARNING',
+      message: 'No watch state recorded',
+      suggestion: 'Run `librarian watch` to keep the index up-to-date.',
+    };
+  }
+  if (watchState?.last_error) {
+    return {
+      name: 'Watch Freshness',
+      status: 'WARNING',
+      message: `Watch degraded: last error ${watchState.last_error}`,
+      suggestion: 'Run `librarian watch` to restart indexing and catch up on changes',
+    };
+  }
+  if (health?.suspectedDead) {
+    return {
+      name: 'Watch Freshness',
+      status: 'WARNING',
+      message: 'Watch degraded: suspected dead',
+      suggestion: 'Run `librarian watch` to restart indexing and catch up on changes',
+    };
+  }
+  if (watchState?.needs_catchup) {
+    return {
+      name: 'Watch Freshness',
+      status: 'WARNING',
+      message: 'Watch degraded: needs catch-up',
+      suggestion: 'Run `librarian watch` to restart indexing and catch up on changes',
+    };
+  }
+  return {
+    name: 'Watch Freshness',
+    status: 'OK',
+    message: 'Watch freshness healthy',
+  };
+}
+
+function createLockHealthCheck(report: StatusReport): HealthCheck {
+  const locks = report.locks;
+  if (!locks) {
+    return {
+      name: 'Lock File Staleness',
+      status: 'OK',
+      message: 'No lock metadata recorded',
+    };
+  }
+  if ((locks.staleFiles ?? 0) > 0) {
+    return {
+      name: 'Lock File Staleness',
+      status: 'WARNING',
+      message: `Detected ${locks.staleFiles} stale lock file(s)`,
+      suggestion: 'Run `librarian doctor --heal` to safely remove stale lock files',
+    };
+  }
+  if ((locks.unknownFreshFiles ?? 0) > 0) {
+    return {
+      name: 'Lock File Staleness',
+      status: 'WARNING',
+      message: `Found ${locks.unknownFreshFiles} lock file(s) with unknown PID`,
+      suggestion: 'If indexing appears stuck, run `librarian doctor --heal`',
+    };
+  }
+  return {
+    name: 'Lock File Staleness',
+    status: 'OK',
+    message: 'No stale lock files detected',
+  };
+}
+
+function createEmbeddingCoverageHealthCheck(report: StatusReport): HealthCheck {
+  const totalFunctions = report.stats?.totalFunctions ?? 0;
+  const totalEmbeddings = report.stats?.totalEmbeddings ?? 0;
+  if (totalFunctions === 0) {
+    return {
+      name: 'Functions/Embeddings Correlation',
+      status: 'WARNING',
+      message: 'No functions indexed',
+      suggestion: 'Run `librarian bootstrap` to index codebase',
+    };
+  }
+  if (totalEmbeddings === 0) {
+    return {
+      name: 'Functions/Embeddings Correlation',
+      status: 'ERROR',
+      message: `${totalFunctions} functions but 0 embeddings`,
+      suggestion: 'Embedding model may have failed. Run `librarian bootstrap --force`',
+    };
+  }
+  const coverage = (totalEmbeddings / totalFunctions) * 100;
+  if (coverage < 20) {
+    return {
+      name: 'Functions/Embeddings Correlation',
+      status: 'ERROR',
+      message: `Critical embedding coverage: ${coverage.toFixed(1)}% (${totalEmbeddings}/${totalFunctions})`,
+      suggestion: 'Embedding generation likely failed. Run `librarian bootstrap --force` and verify provider health.',
+    };
+  }
+  if (coverage < 80) {
+    return {
+      name: 'Functions/Embeddings Correlation',
+      status: 'WARNING',
+      message: `Partial embedding coverage: ${coverage.toFixed(1)}% (${totalEmbeddings}/${totalFunctions})`,
+      suggestion: 'Some functions may be missing embeddings. Consider rebootstrapping.',
+    };
+  }
+  return {
+    name: 'Functions/Embeddings Correlation',
+    status: 'OK',
+    message: `${totalFunctions} functions, ${totalEmbeddings} embeddings (${coverage.toFixed(1)}% coverage)`,
+  };
+}
+
+function createModulesHealthCheck(report: StatusReport): HealthCheck {
+  const totalModules = report.stats?.totalModules ?? 0;
+  const totalFunctions = report.stats?.totalFunctions ?? 0;
+  if (totalModules === 0 && totalFunctions > 0) {
+    return {
+      name: 'Modules Indexed',
+      status: 'WARNING',
+      message: 'No modules indexed but functions exist',
+      suggestion: 'Module extraction may have failed',
+    };
+  }
+  if (totalModules === 0) {
+    return {
+      name: 'Modules Indexed',
+      status: 'WARNING',
+      message: 'No modules indexed',
+      suggestion: 'Run `librarian bootstrap` to index codebase',
+    };
+  }
+  return {
+    name: 'Modules Indexed',
+    status: 'OK',
+    message: `${totalModules} modules indexed`,
+  };
+}
+
+function createContextPackHealthCheck(report: StatusReport): HealthCheck {
+  const totalContextPacks = report.stats?.totalContextPacks ?? 0;
+  if (totalContextPacks === 0) {
+    return {
+      name: 'Context Packs Health',
+      status: 'WARNING',
+      message: 'No context packs generated',
+      suggestion: 'Run `librarian bootstrap` to generate context packs',
+    };
+  }
+  return {
+    name: 'Context Packs Health',
+    status: 'OK',
+    message: `${totalContextPacks} context packs available`,
+  };
+}
+
+function createConfidenceHealthCheck(report: StatusReport): HealthCheck {
+  const avgConfidence = report.stats?.averageConfidence ?? 0;
+  const totalFunctions = report.stats?.totalFunctions ?? 0;
+  const totalModules = report.stats?.totalModules ?? 0;
+  if (totalFunctions === 0) {
+    return {
+      name: 'Knowledge Confidence',
+      status: totalModules > 0 ? 'WARNING' : 'OK',
+      message: totalModules > 0
+        ? 'No functions indexed; confidence metrics are incomplete'
+        : 'No code entities indexed; confidence metrics unavailable',
+      suggestion: totalModules > 0 ? 'Index code with functions for richer confidence signals' : undefined,
+    };
+  }
+  if (avgConfidence < 0.3) {
+    return {
+      name: 'Knowledge Confidence',
+      status: 'ERROR',
+      message: `Very low average confidence: ${(avgConfidence * 100).toFixed(1)}%`,
+      suggestion: 'Knowledge quality is poor. Consider rebootstrapping.',
+    };
+  }
+  if (avgConfidence < 0.5) {
+    return {
+      name: 'Knowledge Confidence',
+      status: 'WARNING',
+      message: `Low average confidence: ${(avgConfidence * 100).toFixed(1)}%`,
+      suggestion: 'Some knowledge may be unreliable',
+    };
+  }
+  return {
+    name: 'Knowledge Confidence',
+    status: 'OK',
+    message: `Average confidence healthy at ${(avgConfidence * 100).toFixed(1)}%`,
+  };
+}
+
+function createEmbeddingProviderHealthCheck(report: StatusReport): HealthCheck {
+  const providers = report.providers?.status;
+  if (!providers) {
+    return {
+      name: 'Embedding Provider',
+      status: 'ERROR',
+      message: `Embedding provider unavailable: ${report.providers?.error ?? 'unknown'}`,
+      suggestion: 'Check embedding provider installation or run `librarian check-providers`',
+    };
+  }
+  if (!providers.embedding.available) {
+    return {
+      name: 'Embedding Provider',
+      status: 'ERROR',
+      message: `Embedding provider unavailable: ${providers.embedding.error ?? 'unknown'}`,
+      suggestion: 'Check embedding provider installation or run `librarian check-providers`',
+    };
+  }
+  return {
+    name: 'Embedding Provider',
+    status: 'OK',
+    message: `Embedding provider ready (${providers.embedding.provider})`,
+  };
+}
+
+function createLlmProviderHealthCheck(report: StatusReport): HealthCheck {
+  const providers = report.providers?.status;
+  if (!providers) {
+    return {
+      name: 'LLM Provider',
+      status: 'WARNING',
+      message: `LLM provider unavailable: ${report.providers?.error ?? 'unknown'}`,
+      suggestion: 'Run `claude` or `codex login` to authenticate',
+    };
+  }
+  if (!providers.llm.available) {
+    return {
+      name: 'LLM Provider',
+      status: 'WARNING',
+      message: `LLM provider unavailable: ${providers.llm.error ?? 'unknown'}`,
+      suggestion: 'Run `claude` or `codex login` to authenticate',
+    };
+  }
+  return {
+    name: 'LLM Provider',
+    status: 'OK',
+    message: `LLM provider ready (${providers.llm.provider}: ${providers.llm.model})`,
+  };
 }
 
 function parseWorkspaceSetArg(rawArgs: string[] | undefined): string | undefined {


### PR DESCRIPTION
## Summary
- share cross-DB consistency evaluation between status and doctor
- include cross-DB consistency in the shared readiness summary used for top-level health
- add regressions proving both commands flip to ERROR for the same critical condition

## Validation
- npm run build
- npm test -- --run src/cli/commands/__tests__/status.test.ts src/cli/commands/__tests__/doctor.test.ts
- npm test -- --run src/constructions/processes/__tests__/cli_output_sanity_gate.test.ts
- npm test -- --run
- node dist/cli/index.js status --json
- node dist/cli/index.js doctor --json
- LIBRARIAN_LLM_PROVIDER=codex ./ask --json "How do the status and doctor commands compute health status?"
- node scripts/issue-quality-analysis.mjs 909 --description "shared status and doctor health summary" --verdict insufficient_evidence ...

Fixes #909